### PR TITLE
isodatetime: fix recurring recurrence format 1

### DIFF
--- a/isodatetime/data.py
+++ b/isodatetime/data.py
@@ -169,7 +169,8 @@ class TimeRecurrence(object):
             return next_timepoint
         if (self.format_number == 1 and next_timepoint > self.end_point):
             diff = next_timepoint - self.end_point
-            if 2 * diff < self.interval and self.get_is_valid(self.end_point):
+            if (2 * diff < self.interval and
+                    self._get_is_in_bounds(self.end_point)):
                 return self.end_point
         return None
 


### PR DESCRIPTION
This fixes a bug from pull request #23, which causes an infinite loop
for recurrence format 1. The get_is_valid call calls self.**iter** which
calls get_next again.

This fixes the bug.

@arjclark, please review.
