### PR TITLE
Fix get next point for single-repetition recurrences

### DIFF
--- a/isodatetime/data.py
+++ b/isodatetime/data.py
@@ -164,7 +164,7 @@ class TimeRecurrence(object):
 
     def get_next(self, timepoint):
         """Return the next timepoint after this timepoint, or None."""
-        if self.repetitions == 1:
+        if self.repetitions == 1 or timepoint is None:
             return None
         next_timepoint = timepoint + self.interval
         if self._get_is_in_bounds(next_timepoint):
@@ -178,7 +178,7 @@ class TimeRecurrence(object):
 
     def get_prev(self, timepoint):
         """Return the previous timepoint before this timepoint, or None."""
-        if self.repetitions == 1:
+        if self.repetitions == 1 or timepoint is None:
             return None
         prev_timepoint = timepoint - self.interval
         if self._get_is_in_bounds(prev_timepoint):

--- a/isodatetime/tests.py
+++ b/isodatetime/tests.py
@@ -634,6 +634,28 @@ class TestSuite(unittest.TestCase):
                     break
                 test_results.append(str(time_point))
             self.assertEqual(test_results, ctrl_results, expression)
+            if test_recurrence.start_point is None:
+                forward_method = test_recurrence.get_prev
+                backward_method = test_recurrence.get_next
+            else:
+                forward_method = test_recurrence.get_next
+                backward_method = test_recurrence.get_prev
+            test_points = [test_recurrence[0]]
+            test_points.append(forward_method(test_points[-1]))
+            test_points.append(forward_method(test_points[-1]))
+            test_results = [str(point) for point in test_points]
+            self.assertEqual(test_results, ctrl_results, expression)
+            if test_recurrence[2] is not None:
+                test_points = [test_recurrence[2]]
+                test_points.append(backward_method(test_points[-1]))
+                test_points.append(backward_method(test_points[-1]))
+                test_points.append(backward_method(test_points[-1]))
+            self.assertEqual(test_points[3], None, expression)
+            test_points.pop(3)
+            test_points.reverse()
+            test_results = [str(point) for point in test_points]
+            self.assertEqual(test_results, ctrl_results, expression)
+            
         for expression, results in get_timerecurrence_membership_tests():
             try:
                 test_recurrence = parser.parse(expression)


### PR DESCRIPTION
This fixes the case where a recurrence has a single repetition
(i.e. a null interval) and the `get_next` method is called.

@arjclark, please review.

Tests pass.
