### PR TITLE
strptime/strftime: remove %y support.

### DIFF
--- a/isodatetime/parser_spec.py
+++ b/isodatetime/parser_spec.py
@@ -260,12 +260,10 @@ STRFTIME_TRANSLATE_INFO = {
         "%(seconds_since_unix_epoch)s", "seconds_since_unix_epoch"),
     "%S": ["second_of_minute"],
     "%X": ["hour_of_day", ":", "minute_of_hour", ":", "second_of_minute"],
-    "%y": ["year_of_century"],
     "%Y": ["century", "year_of_century"],
     "%z": LOCALE_TIMEZONE_BASIC_NO_Z,
 }
 STRPTIME_EXCLUSIVE_GROUP_INFO = {
-    "%Y": ("%y",),
     "%X": ("%H", "%M", "%S"),
     "%F": ("%Y", "%y", "%m", "%d"),
     "%s": tuple([i for i in STRFTIME_TRANSLATE_INFO if i != "%s"])


### PR DESCRIPTION
This has been removed since the POSIX standard
requires guessing the century from a `%y` strptime,
and also states that the method of guessing may
change in future standards. This is too unstable
to use.

@matthewrmshin, please review.

Tests pass.
