### PR TITLE
add `__version__` information

### DIFF
--- a/isodatetime/__init__.py
+++ b/isodatetime/__init__.py
@@ -15,3 +15,5 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-----------------------------------------------------------------------------
+
+__version__ = "2014-03+"


### PR DESCRIPTION
This adds `__version__` information more-or-less as specified in
[PEP 396](http://legacy.python.org/dev/peps/pep-0396/).

@matthewrmshin, please review.
