### PR TITLE
Set the local time zone as the default

### DIFF
--- a/isodatetime/data.py
+++ b/isodatetime/data.py
@@ -563,11 +563,11 @@ class TimePoint(object):
     for leap seconds at 60 yet)
     second_of_minute_decimal - a float between 0 and 1, if using decimal
     accuracy for seconds.
-    time_zone_hour - (default 0) an integer denoting the hour timezone
+    time_zone_hour - (default 0) an integer denoting the hour time zone
     offset from UTC. Note that unless this is a truncated
     representation, 0 will be assumed if this is not provided.
     time_zone_minute - (default 0) an integer between 0 and 59 denoting
-    the minute component of the timezone offset from UTC.
+    the minute component of the time zone offset from UTC.
     dump_format - a custom format string to control the stringification
     of the timepoint. See isodatetime.parser_spec for more details.
     truncated - (default False) a boolean denoting whether the
@@ -919,8 +919,8 @@ class TimePoint(object):
         self.time_zone = dest_time_zone
 
     def set_time_zone_to_local(self):
-        """Set the time zone to the local timezone, if it's not already."""
-        local_hours, local_minutes = timezone.get_timezone_for_locale()
+        """Set the time zone to the local time zone, if it's not already."""
+        local_hours, local_minutes = timezone.get_local_time_zone()
         self.set_time_zone(TimeZone(hours=local_hours, minutes=local_minutes))
 
     def set_time_zone_to_utc(self):

--- a/isodatetime/dumpers.py
+++ b/isodatetime/dumpers.py
@@ -35,7 +35,7 @@ class TimePointDumper(object):
     of valid patterns is found in the parser_spec module, with lots
     of examples (coincidentally, used to generate the parsing).
     Anything not matched will get left as it is in the string.
-    Specifying a particular timezone will result in a timezone
+    Specifying a particular time zone will result in a time zone
     conversion of the date/time information before it is output.
 
     For example, the following formatting_string
@@ -47,7 +47,7 @@ class TimePointDumper(object):
     T - left alone, date/time separator
     hh - hour of day information, e.g. 06
     mm - minute of hour information, e.g. 58
-    Z - Zulu or UTC zero-offset timezone, left in, forces timezone
+    Z - Zulu or UTC zero-offset time zone, left in, forces time zone
     conversion
     and might dump a TimePoint instance like this: '19850531T0658Z'.
 
@@ -66,7 +66,7 @@ class TimePointDumper(object):
                     num_expanded_year_digits),
                  "date"),
                 (parser_spec.get_time_translate_info(), "time"),
-                (parser_spec.get_timezone_translate_info(), "time_zone")]:
+                (parser_spec.get_time_zone_translate_info(), "time_zone")]:
             for regex, regex_sub, format_sub, prop_name in info:
                 rec = re.compile(regex)
                 self._rec_formats[key].append((rec, format_sub, prop_name))
@@ -193,10 +193,10 @@ class TimePointDumper(object):
             self._timepoint_parser = parsers.TimePointParser()
         try:
             (expr, info) = (
-                self._timepoint_parser.get_timezone_info(time_zone_string))
+                self._timepoint_parser.get_time_zone_info(time_zone_string))
         except parsers.ISO8601SyntaxError as e:
             return None
-        info = self._timepoint_parser.process_timezone_info(info)
+        info = self._timepoint_parser.process_time_zone_info(info)
         if info.get('time_zone_utc'):
             return (0, 0)
         if "time_zone_hour" not in info and "time_zone_minute" not in info:

--- a/isodatetime/parser_spec.py
+++ b/isodatetime/parser_spec.py
@@ -151,7 +151,7 @@ hh             # Deviation? Not allowed in standard ?
 --ss.tt         # Deviation? Not allowed in standard ?
 """    }
 }
-TIMEZONE_EXPRESSIONS = {
+TIME_ZONE_EXPRESSIONS = {
     "basic": u"""
 Z
 ±hh
@@ -220,7 +220,7 @@ _TIME_TRANSLATE_INFO = [
     (u"^-", "(?P<truncated>-)",
      "-", None)
 ]
-_TIMEZONE_TRANSLATE_INFO = [
+_TIME_ZONE_TRANSLATE_INFO = [
     (u"(?<=±hh)mm", "(?P<time_zone_minute>\d\d)",
      "%(time_zone_minute_abs)02d", "time_zone_minute_abs"),
     (u"(?<=±hh:)mm", "(?P<time_zone_minute>\d\d)",
@@ -233,15 +233,15 @@ _TIMEZONE_TRANSLATE_INFO = [
      "Z", None)
 ]
 
-LOCALE_TIMEZONE_BASIC = timezone.get_timezone_format_for_locale()
-LOCALE_TIMEZONE_BASIC_NO_Z = LOCALE_TIMEZONE_BASIC
-if LOCALE_TIMEZONE_BASIC_NO_Z == "Z":
-    LOCALE_TIMEZONE_BASIC_NO_Z = "+0000"
-LOCALE_TIMEZONE_EXTENDED = timezone.get_timezone_format_for_locale(
+LOCAL_TIME_ZONE_BASIC = timezone.get_local_time_zone_format()
+LOCAL_TIME_ZONE_BASIC_NO_Z = LOCAL_TIME_ZONE_BASIC
+if LOCAL_TIME_ZONE_BASIC_NO_Z == "Z":
+    LOCAL_TIME_ZONE_BASIC_NO_Z = "+0000"
+LOCAL_TIME_ZONE_EXTENDED = timezone.get_local_time_zone_format(
     extended_mode=True)
-LOCALE_TIMEZONE_EXTENDED_NO_Z = LOCALE_TIMEZONE_EXTENDED
-if LOCALE_TIMEZONE_EXTENDED_NO_Z == "Z":
-    LOCALE_TIMEZONE_EXTENDED_NO_Z = "+0000"
+LOCAL_TIME_ZONE_EXTENDED_NO_Z = LOCAL_TIME_ZONE_EXTENDED
+if LOCAL_TIME_ZONE_EXTENDED_NO_Z == "Z":
+    LOCAL_TIME_ZONE_EXTENDED_NO_Z = "+0000"
     
 # Note: we only accept the following subset of strftime syntax.
 # This is due to inconsistencies with the ISO 8601 representations.
@@ -294,8 +294,8 @@ def get_time_translate_info():
     return _TIME_TRANSLATE_INFO
 
 
-def get_timezone_translate_info():
-    return _TIMEZONE_TRANSLATE_INFO
+def get_time_zone_translate_info():
+    return _TIME_ZONE_TRANSLATE_INFO
 
 
 def translate_strftime_token(strftime_token, num_expanded_year_digits=2):
@@ -323,7 +323,7 @@ def _translate_strftime_token(strftime_token, dump_mode=False,
         get_date_translate_info(
             num_expanded_year_digits=num_expanded_year_digits) +
         get_time_translate_info() +
-        get_timezone_translate_info()
+        get_time_zone_translate_info()
     )
     attr_names = STRFTIME_TRANSLATE_INFO[strftime_token]
     if isinstance(attr_names, basestring):

--- a/isodatetime/parsers.py
+++ b/isodatetime/parsers.py
@@ -133,11 +133,10 @@ class TimePointParser(object):
     whose offset from UTC is the (hours, minutes) information in this
     variable. To assume UTC, set this to (0, 0).
 
-    no_assume_local_time_zone (default False) specifies that dates and
-    times without time zone information (in the absence of
-    assumed_time_zone_hours_minutes), should not be assumed to be
-    in the local time zone. They would then be left with an unknown
-    time zone setting.
+    default_to_unknown_time_zone (default False) specifies that
+    dates and times without time zone information (in the absence of
+    assumed_time_zone) should be left with an unknown time zone
+    setting. Otherwise, the current local time zone will be used.
 
     dump_format (default None) specifies a default custom dump format
     string for TimePoint instances. See data.TimePoint documentation
@@ -149,13 +148,13 @@ class TimePointParser(object):
                  allow_truncated=False,
                  allow_only_basic=False,
                  assumed_time_zone=None,
-                 no_assume_local_time_zone=False,
+                 default_to_unknown_time_zone=False,
                  dump_format=None):
         self.expanded_year_digits = num_expanded_year_digits
         self.allow_truncated = allow_truncated
         self.allow_only_basic = allow_only_basic
         self.assumed_time_zone = assumed_time_zone
-        self.no_assume_local_time_zone = no_assume_local_time_zone
+        self.default_to_unknown_time_zone = default_to_unknown_time_zone
         self.dump_format = dump_format
         self._generate_regexes()
 
@@ -163,17 +162,17 @@ class TimePointParser(object):
         """Generate combined date time strings."""
         date_map = parser_spec.DATE_EXPRESSIONS
         time_map = parser_spec.TIME_EXPRESSIONS
-        timezone_map = parser_spec.TIMEZONE_EXPRESSIONS
+        time_zone_map = parser_spec.TIME_ZONE_EXPRESSIONS
         self._date_regex_map = {}
         self._time_regex_map = {}
-        self._timezone_regex_map = {}
+        self._time_zone_regex_map = {}
         format_ok_keys = ["basic", "extended"]
         if self.allow_only_basic:
             format_ok_keys = ["basic"]
         for format_type in format_ok_keys:
             self._date_regex_map.setdefault(format_type, {})
             self._time_regex_map.setdefault(format_type, {})
-            self._timezone_regex_map.setdefault(format_type, [])
+            self._time_zone_regex_map.setdefault(format_type, [])
             for date_key in date_map[format_type].keys():
                 self._date_regex_map[format_type].setdefault(date_key, [])
                 regex_list = self._date_regex_map[format_type][date_key]
@@ -190,12 +189,12 @@ class TimePointParser(object):
                     time_regex = self.parse_time_expression_to_regex(
                         time_expr)
                     regex_list.append([re.compile(time_regex), time_expr])
-            for timezone_expr in self.get_expressions(
-                    timezone_map[format_type]):
-                timezone_regex = self.parse_timezone_expression_to_regex(
-                    timezone_expr)
-                self._timezone_regex_map[format_type].append(
-                    [re.compile(timezone_regex), timezone_expr])
+            for time_zone_expr in self.get_expressions(
+                    time_zone_map[format_type]):
+                time_zone_regex = self.parse_time_zone_expression_to_regex(
+                    time_zone_expr)
+                self._time_zone_regex_map[format_type].append(
+                    [re.compile(time_zone_regex), time_zone_expr])
 
     def get_expressions(self, text):
         """Yield valid expressions from text."""
@@ -223,10 +222,10 @@ class TimePointParser(object):
         expression = "^" + expression + "$"
         return expression
 
-    def parse_timezone_expression_to_regex(self, expression):
-        """Construct regular expressions for the timezone."""
+    def parse_time_zone_expression_to_regex(self, expression):
+        """Construct regular expressions for the time zone."""
         for expr_regex, substitute, format_, name in (
-                parser_spec.get_timezone_translate_info(
+                parser_spec.get_time_zone_translate_info(
                     )):
             expression = re.sub(expr_regex, substitute, expression)
         expression = "^" + expression + "$"
@@ -361,16 +360,16 @@ class TimePointParser(object):
             time_info_keys.append(name)
         date_info = {}
         time_info = {}
-        timezone_info = {}
+        time_zone_info = {}
         for key, value in info.items():
             if key in date_info_keys:
                 date_info[key] = value
             elif key in time_info_keys:
                 time_info[key] = value
             else:
-                timezone_info[key] = value
-        timezone_info = self.process_timezone_info(timezone_info)
-        time_info.update(timezone_info)
+                time_zone_info[key] = value
+        time_zone_info = self.process_time_zone_info(time_zone_info)
+        time_info.update(time_zone_info)
         return self._create_timepoint_from_info(
             date_info, time_info, dump_format=dump_format)
 
@@ -410,35 +409,35 @@ class TimePointParser(object):
                         return expr, result.groupdict()
         raise ISO8601SyntaxError("time", time_string)
 
-    def get_timezone_info(self, timezone_string, bad_formats=None):
-        """Return the properties from a timezone string."""
+    def get_time_zone_info(self, time_zone_string, bad_formats=None):
+        """Return the properties from a time zone string."""
         if bad_formats is None:
             bad_formats = []
-        for format_key, regex_list in self._timezone_regex_map.items():
+        for format_key, regex_list in self._time_zone_regex_map.items():
             if format_key in bad_formats:
                 continue
             for regex, expr in regex_list:
-                result = regex.match(timezone_string)
+                result = regex.match(time_zone_string)
                 if result:
                     return expr, result.groupdict()
-        raise ISO8601SyntaxError("timezone", timezone_string)
+        raise ISO8601SyntaxError("time zone", time_zone_string)
 
     def get_info(self, timepoint_string):
         """Return the date and time properties from a timepoint string."""
-        date_time_timezone = timepoint_string.split(
+        date_time_time_zone = timepoint_string.split(
             parser_spec.TIME_DESIGNATOR)
         parsed_expr = ""
-        if len(date_time_timezone) == 1:
-            date = date_time_timezone[0]
+        if len(date_time_time_zone) == 1:
+            date = date_time_time_zone[0]
             keys, date_info = self.get_date_info(date)
             format_key, type_key, date_expr = keys
             parsed_expr += date_expr
             time_info = {}
-            timezone_info = (
-                self.process_timezone_info({}))
-            time_info.update(timezone_info)
+            time_zone_info = (
+                self.process_time_zone_info({}))
+            time_info.update(time_zone_info)
         else:
-            date, time_timezone = date_time_timezone
+            date, time_time_zone = date_time_time_zone
             if not date and self.allow_truncated:
                 keys = (None, "truncated", "")
                 date_info = {"truncated": True}
@@ -458,14 +457,14 @@ class TimePointParser(object):
             bad_types = ["truncated"]
             if date_info.get("truncated"):
                 bad_types = []
-            if time_timezone.endswith("Z"):
-                time, timezone = time_timezone[:-1], "Z"
-            elif "+" in time_timezone:
-                time, timezone = time_timezone.split("+")
-                timezone = "+" + timezone
-            elif "-" in time_timezone:
-                time, timezone = time_timezone.rsplit("-", 1)
-                timezone = "-" + timezone
+            if time_time_zone.endswith("Z"):
+                time, time_zone = time_time_zone[:-1], "Z"
+            elif "+" in time_time_zone:
+                time, time_zone = time_time_zone.split("+")
+                time_zone = "+" + time_zone
+            elif "-" in time_time_zone:
+                time, time_zone = time_time_zone.rsplit("-", 1)
+                time_zone = "-" + time_zone
                 # Make sure this isn't just a truncated time.
                 try:
                     time_expr, time_info = self.get_time_info(
@@ -473,62 +472,65 @@ class TimePointParser(object):
                         bad_formats=bad_formats,
                         bad_types=bad_types
                     )
-                    timezone_expr, timezone_info = self.get_timezone_info(
-                        timezone,
+                    time_zone_expr, time_zone_info = self.get_time_zone_info(
+                        time_zone,
                         bad_formats=bad_formats
                     )
                 except ISO8601SyntaxError:
-                    time = time_timezone
-                    timezone = None
+                    time = time_time_zone
+                    time_zone = None
             else:
-                time = time_timezone
-                timezone = None
-            if timezone is None:
-                timezone_info = {}
-                timezone_expr = ""
-                timezone_info = (
-                    self.process_timezone_info(timezone_info))
+                time = time_time_zone
+                time_zone = None
+            if time_zone is None:
+                time_zone_info = {}
+                time_zone_expr = ""
+                time_zone_info = (
+                    self.process_time_zone_info(time_zone_info))
             else:
-                timezone_expr, timezone_info = self.get_timezone_info(
-                    timezone,
+                time_zone_expr, time_zone_info = self.get_time_zone_info(
+                    time_zone,
                     bad_formats=bad_formats
                 )
-                timezone_info = self.process_timezone_info(timezone_info)
+                time_zone_info = self.process_time_zone_info(time_zone_info)
             time_expr, time_info = self.get_time_info(
                                            time, bad_formats=bad_formats,
                                            bad_types=bad_types)
             parsed_expr += parser_spec.TIME_DESIGNATOR + (
-                time_expr + timezone_expr)
-            time_info.update(timezone_info)
+                time_expr + time_zone_expr)
+            time_info.update(time_zone_info)
         return date_info, time_info, parsed_expr
 
-    def process_timezone_info(self, timezone_info):
-        if not timezone_info:
+    def process_time_zone_info(self, time_zone_info=None):
+        """Rationalise time zone data and set defaults if appropriate."""
+        if time_zone_info is None:
+            time_zone_info = {}
+        if not time_zone_info:
             # There is no time zone information specified.
             if self.assumed_time_zone is None:
                 # No given value to assume.
-                if self.no_assume_local_time_zone:
+                if self.default_to_unknown_time_zone:
                     # Return no time zone information.
-                    return timezone_info 
+                    return {} 
                 # Set the time zone to the current local time zone.
                 utc_hour_offset, utc_minute_offset = (
-                    timezone.get_timezone_for_locale())
-                timezone_info["time_zone_hour"] = utc_hour_offset
-                timezone_info["time_zone_minute"] = utc_minute_offset
-                return timezone_info
+                    timezone.get_local_time_zone())
+                time_zone_info["time_zone_hour"] = utc_hour_offset
+                time_zone_info["time_zone_minute"] = utc_minute_offset
+                return time_zone_info
             else:
                 # Set the time zone to a given value.
                 utc_hour_offset, utc_minute_offset = self.assumed_time_zone
-                timezone_info["time_zone_hour"] = utc_hour_offset
-                timezone_info["time_zone_minute"] = utc_minute_offset
-                return timezone_info
-        if timezone_info.pop("time_zone_sign", "+") == "-":
-            timezone_info["time_zone_hour"] = (
-                -int(timezone_info["time_zone_hour"]))
-            if "time_zone_minute" in timezone_info:
-                timezone_info["time_zone_minute"] = (
-                    -int(timezone_info["time_zone_minute"]))
-        return timezone_info
+                time_zone_info["time_zone_hour"] = utc_hour_offset
+                time_zone_info["time_zone_minute"] = utc_minute_offset
+                return time_zone_info
+        if time_zone_info.pop("time_zone_sign", "+") == "-":
+            time_zone_info["time_zone_hour"] = (
+                -int(time_zone_info["time_zone_hour"]))
+            if "time_zone_minute" in time_zone_info:
+                time_zone_info["time_zone_minute"] = (
+                    -int(time_zone_info["time_zone_minute"]))
+        return time_zone_info
 
 
 class TimeIntervalParser(object):

--- a/isodatetime/tests.py
+++ b/isodatetime/tests.py
@@ -410,7 +410,7 @@ def get_timepointparser_tests(allow_only_basic=False,
             }
         }
     }
-    test_timezone_map = {
+    test_time_zone_map = {
         "basic": {
             "Z": {"time_zone_hour": 0, "time_zone_minute": 0},
             "+01": {"time_zone_hour": 1},
@@ -437,7 +437,7 @@ def get_timepointparser_tests(allow_only_basic=False,
     for format_type in format_ok_keys:
         date_format_tests = test_date_map[format_type]
         time_format_tests = test_time_map[format_type]
-        timezone_format_tests = test_timezone_map[format_type]
+        time_zone_format_tests = test_time_zone_map[format_type]
         for date_key in date_format_tests:
             if not allow_truncated and date_key == "truncated":
                 continue
@@ -461,12 +461,12 @@ def get_timepointparser_tests(allow_only_basic=False,
                         yield combo_expr, combo_info
                         if skip_time_zones:
                             continue
-                        timezone_items = timezone_format_tests.items()
-                        for timezone_expr, timezone_info in timezone_items:
-                            tz_expr = combo_expr + timezone_expr
+                        time_zone_items = time_zone_format_tests.items()
+                        for time_zone_expr, time_zone_info in time_zone_items:
+                            tz_expr = combo_expr + time_zone_expr
                             tz_info = {}
                             for key, value in (combo_info.items() +
-                                                timezone_info.items()):
+                                                time_zone_info.items()):
                                 tz_info[key] = value
                             yield tz_expr, tz_info
         if not allow_truncated:
@@ -485,12 +485,12 @@ def get_timepointparser_tests(allow_only_basic=False,
                 yield combo_expr, combo_info
                 if skip_time_zones:
                     continue
-                timezone_items = timezone_format_tests.items()
-                for timezone_expr, timezone_info in timezone_items:
-                    tz_expr = combo_expr + timezone_expr
+                time_zone_items = time_zone_format_tests.items()
+                for time_zone_expr, time_zone_info in time_zone_items:
+                    tz_expr = combo_expr + time_zone_expr
                     tz_info = {}
                     for key, value in (combo_info.items() +
-                                        timezone_info.items()):
+                                        time_zone_info.items()):
                         tz_info[key] = value
                     yield tz_expr, tz_info
 
@@ -613,8 +613,8 @@ def get_timerecurrenceparser_tests():
                                 "end_point": end_point}
 
 
-def get_locale_time_zone_hours_minutes():
-    """Provide an independent method of getting the local timezone."""
+def get_local_time_zone_hours_minutes():
+    """Provide an independent method of getting the local time zone."""
     import datetime
     utc_offset = datetime.datetime.now() - datetime.datetime.utcnow()
     utc_offset_hours = (utc_offset.seconds + 1800) // 3600
@@ -725,13 +725,13 @@ class TestSuite(unittest.TestCase):
             timedelta = datetime.timedelta(days=1)
             my_date += timedelta
 
-    def test_timepoint_timezone(self):
-        """Test the timezone handling of timepoint instances."""
+    def test_timepoint_time_zone(self):
+        """Test the time zone handling of timepoint instances."""
         year = 2000
         month_of_year = 1
         day_of_month = 1
         utc_offset_hours, utc_offset_minutes = (
-            get_locale_time_zone_hours_minutes()
+            get_local_time_zone_hours_minutes()
         )
         for hour_of_day in range(24):
             for minute_of_hour in [0, 30]:
@@ -796,7 +796,7 @@ class TestSuite(unittest.TestCase):
     def test_timepoint_dumper(self):
         """Test the dumping of TimePoint instances."""
         parser = parsers.TimePointParser(allow_truncated=True,
-                                         no_assume_local_time_zone=True)
+                                         default_to_unknown_time_zone=True)
         dumper = dumpers.TimePointDumper()
         for expression, timepoint_kwargs in get_timepointparser_tests(
                 allow_truncated=True):
@@ -820,8 +820,9 @@ class TestSuite(unittest.TestCase):
         """Test the parsing of date/time expressions."""
 
         # Test unknown time zone assumptions.
-        parser = parsers.TimePointParser(allow_truncated=True,
-                                         no_assume_local_time_zone=True)
+        parser = parsers.TimePointParser(
+            allow_truncated=True,
+            default_to_unknown_time_zone=True)
         for expression, timepoint_kwargs in get_timepointparser_tests(
                 allow_truncated=True):
             timepoint_kwargs = copy.deepcopy(timepoint_kwargs)
@@ -838,7 +839,7 @@ class TestSuite(unittest.TestCase):
 
         # Test local time zone assumptions (the default).
         utc_offset_hours, utc_offset_minutes = (
-            get_locale_time_zone_hours_minutes()
+            get_local_time_zone_hours_minutes()
         )
         parser = parsers.TimePointParser(allow_truncated=True)
         for expression, timepoint_kwargs in get_timepointparser_tests(
@@ -853,11 +854,11 @@ class TestSuite(unittest.TestCase):
                          test_timepoint.time_zone.minutes)
             ctrl_data = (utc_offset_hours, utc_offset_minutes)
             self.assertEqual(test_data, ctrl_data,
-                             "Local timezone for " + expression)
+                             "Local time zone for " + expression)
 
         # Test given time zone assumptions.
         utc_offset_hours, utc_offset_minutes = (
-            get_locale_time_zone_hours_minutes()
+            get_local_time_zone_hours_minutes()
         )
         given_utc_offset_hours = -2  # This is an arbitrary number!
         if given_utc_offset_hours == utc_offset_hours:
@@ -882,7 +883,7 @@ class TestSuite(unittest.TestCase):
                          test_timepoint.time_zone.minutes)
             ctrl_data = given_time_zone_hours_minutes
             self.assertEqual(test_data, ctrl_data,
-                             "A given timezone for " + expression)
+                             "A given time zone for " + expression)
 
         # Test UTC time zone assumptions.
         parser = parsers.TimePointParser(

--- a/isodatetime/timezone.py
+++ b/isodatetime/timezone.py
@@ -16,13 +16,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-----------------------------------------------------------------------------
 
-"""This provides utilites for extracting the local timezone."""
+"""This provides utilites for extracting the local time zone."""
 
 import time
 
 
-def get_timezone_for_locale():
-    """Return the UTC offset for this locale in hours and minutes."""
+def get_local_time_zone():
+    """Return the current local UTC offset in hours and minutes."""
     utc_offset_seconds = -time.timezone
     if time.localtime().tm_isdst == 1 and time.daylight:
         utc_offset_seconds = -time.altzone
@@ -31,9 +31,9 @@ def get_timezone_for_locale():
     return utc_offset_hours, utc_offset_minutes
 
 
-def get_timezone_format_for_locale(extended_mode=False, reduced_mode=False):
-    """Return the timezone format string for this locale (e.g. '+0300')."""
-    utc_offset_hours, utc_offset_minutes = get_timezone_for_locale()
+def get_local_time_zone_format(extended_mode=False, reduced_mode=False):
+    """Return a string denoting the current local UTC offset."""
+    utc_offset_hours, utc_offset_minutes = get_local_time_zone()
     if utc_offset_hours == 0 and utc_offset_minutes == 0:
         return "Z"
     reduced_timezone_template = "%s%02d"


### PR DESCRIPTION
This change allows the `TimePointParser` class to cast date/time
representations with unknown time zones into the local
time zone by default (although there are two switches,
`assume_utc` and `assume_unknown_time_zone` that switch off
this behaviour). Previously, they became UTC by default, which
goes against the spirit of the standard.

This change should be merged after #42.

@arjclark, please review.
