### PR TITLE
Speed up tests

### DIFF
--- a/isodatetime/data.py
+++ b/isodatetime/data.py
@@ -85,14 +85,16 @@ class Calendar(object):
 
     def set_365(self):
         """Use a 365-day calendar."""
-        self.DAYS_IN_MONTHS = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+        self.DAYS_IN_MONTHS = [
+            31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
         self.DAYS_IN_MONTHS_LEAP = self.DAYS_IN_MONTHS
         self.mode = self.MODE_365
         self.recalculate()
 
     def set_366(self):
         """Use a 366-day calendar."""
-        self.DAYS_IN_MONTHS = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+        self.DAYS_IN_MONTHS = [
+            31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
         self.DAYS_IN_MONTHS_LEAP = self.DAYS_IN_MONTHS
         self.mode = self.MODE_366
         self.recalculate()

--- a/isodatetime/tests.py
+++ b/isodatetime/tests.py
@@ -1228,6 +1228,4 @@ def test_timepoint_at_year(test_year):
 
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(TestSuite)
-    import cProfile
-    cProfile.run("unittest.TextTestRunner(verbosity=2).run(suite)",
-                 sort='cumulative')
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
This speeds up the tests, mostly by:
- speeding up some of the code
- parallelizing the slowest test

Some of the code speed up required some extra calendar-type constants to be
cached (indexed days of month, etc) - I took this opportunity to move them into
a class.

The memoization of some functions has been altered so that the calendar type
is also cached and compared - this means that it's safer to switch calendars after
previous computation has been done.

@arjclark, please review.
