### PR TITLE
Fix floating day_of_month

### DIFF
--- a/isodatetime/data.py
+++ b/isodatetime/data.py
@@ -1430,6 +1430,7 @@ class TimePoint(object):
             self.minute_of_hour = minutes
         if self.hour_of_day is not None:
             num_days, hours = divmod(self.hour_of_day, CALENDAR.HOURS_IN_DAY)
+            num_days = int(num_days)
             if self.day_of_week is not None:
                 self.day_of_week += num_days
             elif self.day_of_month is not None:

--- a/isodatetime/tests.py
+++ b/isodatetime/tests.py
@@ -822,6 +822,11 @@ class TestSuite(unittest.TestCase):
         pool = multiprocessing.Pool(processes=4)
         pool.map_async(test_timepoint_at_year, range(1801, 2403)).get()
 
+    def test_timepoint_plus_float_time_interval_day_of_month_type(self):
+        """Test (TimePoint + TimeInterval).day_of_month is an int."""
+        time_point = data.TimePoint(year=2000) + data.TimeInterval(seconds=1.0)
+        self.assertEqual(type(time_point.day_of_month), int)
+
     def test_timepoint_time_zone(self):
         """Test the time zone handling of timepoint instances."""
         year = 2000


### PR DESCRIPTION
On adding a `TimeInterval` to a `TimePoint`. The `day_of_month` should
be an `int`, not a `float`.
