### PR TITLE
Fix error message from badly formatted duration

### DIFF
--- a/isodatetime/parsers.py
+++ b/isodatetime/parsers.py
@@ -581,7 +581,7 @@ class TimeIntervalParser(object):
                     assumed_time_zone=(0, 0)
                 )
             except ISO8601SyntaxError:
-                raise
+                raise ISO8601SyntaxError("duration", expression)
             if timepoint.get_is_week_date():
                 raise ISO8601SyntaxError("duration", expression)
             result_map = {}


### PR DESCRIPTION
This fixes the particular error message that is reported when
trying to parse a time interval string that's badly formatted.

At the moment, when trying to parse something like:

```
PT5D
```

it reports:

```
isodatetime.parsers.ISO8601SyntaxError: Invalid ISO 8601 date representation: 
```

whereas it now reports:

```
isodatetime.parsers.ISO8601SyntaxError: Invalid ISO 8601 duration representation: PT5D
```

@matthewrmshin, please review.
