### PR TITLE
Fix duration not in weeks + duration in weeks

### DIFF
--- a/isodatetime/data.py
+++ b/isodatetime/data.py
@@ -479,7 +479,8 @@ class Duration(object):
                     return new
                 new.to_days()
             elif other.get_is_in_weeks():
-                other = other.copy().to_days()
+                other = other.copy()
+                other.to_days()
             new.years += other.years
             new.months += other.months
             new.days += other.days

--- a/isodatetime/tests.py
+++ b/isodatetime/tests.py
@@ -969,6 +969,12 @@ class TestSuite(unittest.TestCase):
             self.assertEqual(test_expression, ctrl_expression,
                              str(test_props))
 
+    def test_timeduration_add_week(self):
+        """Test the duration not in weeks add duration in weeks."""
+        self.assertEqual(
+            str(data.Duration(days=7) + data.Duration(weeks=1)),
+            "P14D")
+
     def test_timepoint(self):
         """Test the time point data model (takes a while)."""
         pool = multiprocessing.Pool(processes=4)


### PR DESCRIPTION
`Duration.to_days()` does not return anything, so it should not be assigned to `other`.

From cylc/cylc#2149.