### PR TITLE
Fix time point addition.

### DIFF
--- a/isodatetime/data.py
+++ b/isodatetime/data.py
@@ -1186,9 +1186,11 @@ class TimePoint(object):
                 new.tick_over()
         if month_of_year is not None:
             new.to_calendar_date()
+            new.day_of_month = 0  # tick_over month independent of day.
             while new.month_of_year != month_of_year:
                 new.month_of_year += 1
                 new.tick_over()
+            new.day_of_month = day_of_month
         if year_of_decade is not None:
             new.to_calendar_date()
             new_year_of_decade = new.year % 10

--- a/isodatetime/tests.py
+++ b/isodatetime/tests.py
@@ -689,6 +689,30 @@ def get_timepoint_subtract_tests():
     ]
 
 
+def get_timepoint_add_truncated_tests():
+    """Yields tests for adding truncated timepoints to regular timepoints."""
+    return [
+        (
+            {"year": 2000, "month_of_year": 1, "day_of_month": 2,
+             "hour_of_day": 0, "minute_of_hour": 0, "second_of_minute": 0,
+             "time_zone_hour": 0, "time_zone_minute": 0},
+            {"truncated": True, "month_of_year": 1, "day_of_month": 1,
+             "hour_of_day": 0, "minute_of_hour": 0, "second_of_minute": 0,
+             "time_zone_hour": 0, "time_zone_minute": 0},
+            "2001-01-01T00:00:00Z"
+        ),
+        (
+            {"year": 2000, "month_of_year": 1, "day_of_month": 1,
+             "hour_of_day": 0, "minute_of_hour": 0, "second_of_minute": 0,
+             "time_zone_hour": 0, "time_zone_minute": 0},
+            {"truncated": True, "month_of_year": 3, "day_of_month": 30,
+             "hour_of_day": 0, "minute_of_hour": 0, "second_of_minute": 0,
+             "time_zone_hour": 0, "time_zone_minute": 0},
+            "2000-03-30T00:00:00Z"
+        )
+    ]
+
+
 def get_timerecurrence_expansion_tests():
     """Return test expansion expressions for data.TimeRecurrence."""
     return [
@@ -992,6 +1016,16 @@ class TestSuite(unittest.TestCase):
             point1 = data.TimePoint(**test_props1)
             point2 = data.TimePoint(**test_props2)
             test_string = str(point1 - point2)
+            self.assertEqual(test_string, ctrl_string,
+                             "%s - %s" % (point1, point2))
+
+    def test_timepoint_add_truncated(self):
+        """Test subtracting one time point from another."""
+        for test_props1, test_props2, ctrl_string in (
+                get_timepoint_add_truncated_tests()):
+            point1 = data.TimePoint(**test_props1)
+            point2 = data.TimePoint(**test_props2)
+            test_string = str(point1 + point2)
             self.assertEqual(test_string, ctrl_string,
                              "%s - %s" % (point1, point2))
 


### PR DESCRIPTION
Closes #80 

This behaviour was caused by the `_tick_over` method correctly identifying that there is no 30th of February and rolling the date over to the 1st of March. This typically correct behaviour is not applicable to adding truncated time points as the day of the month needs to be carried over intact so this PR disables it.

The consequence of doing so is that if you try to add an invalid date isodatetime will yield an invalid date, e.g:

`2000-01-01T00:00:00Z + 02-30`
before: `2001-02-01T00:00:00Z`
after: `2001-02-30T00:00:00Z`

__PR for discussion__, is this simple logic change sufficient?