### PR TITLE
Rationalise duration output when subtracting timepoints 

### DIFF
--- a/isodatetime/data.py
+++ b/isodatetime/data.py
@@ -1324,6 +1324,8 @@ class TimePoint(object):
 
     def __sub__(self, other):
         if isinstance(other, TimePoint):
+            if other > self:
+                return -1* (other - self)
             other = other.copy()
             other.set_time_zone(self.get_time_zone())
             my_year, my_day_of_year = self.get_ordinal_date()
@@ -1333,8 +1335,6 @@ class TimePoint(object):
                 diff_day += get_days_in_year_range(other_year, my_year - 1)
             else:
                 diff_day -= get_days_in_year_range(my_year, other_year - 1)
-            if diff_day < 0:
-                return -1 * (other - self)
             my_hour, my_minute, my_second = self.get_hour_minute_second()
             other_hour, other_minute, other_second = (
                 other.get_hour_minute_second())

--- a/isodatetime/data.py
+++ b/isodatetime/data.py
@@ -1325,7 +1325,7 @@ class TimePoint(object):
     def __sub__(self, other):
         if isinstance(other, TimePoint):
             if other > self:
-                return -1* (other - self)
+                return -1 * (other - self)
             other = other.copy()
             other.set_time_zone(self.get_time_zone())
             my_year, my_day_of_year = self.get_ordinal_date()

--- a/isodatetime/tests.py
+++ b/isodatetime/tests.py
@@ -634,6 +634,21 @@ def get_timepoint_subtract_tests():
             "P29DT19H"
         ),
         (
+            {"year": 1969, "month_of_year": 7, "day_of_month": 20,
+             "hour_of_day": 20, "time_zone_hour": 0, "time_zone_minute": 0},
+            {"year": 1969, "month_of_year": 7, "day_of_month": 20,
+             "hour_of_day": 19, "time_zone_hour": 0, "time_zone_minute": 0},
+            "PT1H"
+        ),
+
+        (
+            {"year": 1969, "month_of_year": 7, "day_of_month": 20,
+             "hour_of_day": 19, "time_zone_hour": 0, "time_zone_minute": 0},
+            {"year": 1969, "month_of_year": 7, "day_of_month": 20,
+             "hour_of_day": 20, "time_zone_hour": 0, "time_zone_minute": 0},
+            "-PT1H"
+        ),
+        (
             {"year": 1991, "month_of_year": 5, "day_of_month": 4,
              "hour_of_day": 5, "time_zone_hour": 0, "time_zone_minute": 0},
             {"year": 1991, "month_of_year": 6, "day_of_month": 3,


### PR DESCRIPTION
Rationalise subtracting a later timepoint from an earlier one.
The previous logic would have:
```
20171102T0000Z - 20171102T0600Z => P-1DT18H
```

now produces `-PT6H`.

This is likely to be slower than the original logic, since it checks for A > B each time - the impact on e.g. cylc needs to be evaluated.

The new test with the negative duration (`-PT1H`) does not pass on current master - it produces `P-1DT23H`! 