### PR TITLE
pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
     - "2.6"
     - "2.7"
 install:
-    - pip install pep8
+    - pip install pycodestyle
 script:
     - python -m isodatetime.tests
-    - pep8 -v isodatetime
+    - pycodestyle -v isodatetime


### PR DESCRIPTION
Replace the deprecated `pep8` check with `pycodestyle`.

Note: `pycodestyle` is stricter and will likely flag errors.