### PR TITLE
Add setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@
 .coverage.*
 coverage.xml
 htmlcov/
+
+# distutils files
+dist
+MANIFEST
+isodatetime.egg-info/
+.eggs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ below:
 * Matt Shin (Met Office, UK)
 * Hilary Oliver (NIWA, NZ)
 * Lois Huggett (Met Office, UK)
+* Bruno P. Kinoshita (NIWA, NZ)
 
 (All contributors are identifiable with email addresses in the version control
 logs or otherwise.)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# (C) British Crown Copyright 2013-2018 Met Office.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------------
+
+import os
+from setuptools import setup
+# Monkey patching to disable version normalization, as we are using dates with
+# leading zeroes
+# https://github.com/pypa/setuptools/issues/308
+from setuptools.extern.packaging import version
+from isodatetime import __version__
+
+
+version.Version = version.LegacyVersion
+
+
+def read(fname):
+    """Utility function to read the README file.
+
+    Used for the long_description. It's nice, because now 1) we have a top
+    level README file and 2) it's easier to type in the README file than to
+    put a raw string in below ..."""
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+
+setup(
+    name="isodatetime",
+    version=__version__,
+    author="Met Office",
+    author_email="metomi@metoffice.gov.uk",
+    description=("Python ISO 8601 date time parser and data \
+        model/manipulation utilities"),
+    license="GPL",
+    keywords="isodatetime datetime iso8601 date time parser",
+    url="https://github.com/metomi/isodatetime",
+    packages=['isodatetime'],
+    long_description=read('README.md'),
+    platforms='any',
+    install_requires=[],
+    python_requires='>=2.6, <3.0',
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Other Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2.7",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: Utilities"
+    ],
+)


### PR DESCRIPTION
Hi,

I was [experimenting](https://github.com/kinow/cylc/tree/make-cylc-a-module) to package Cylc with setuptools/distutils, leaving just Cylc code in the repository, and any dependencies that contain customization (like cherrypy). But I think the isodatetime version used in Cylc doesn't have any customization, so I would like to continue my experiment using isodatetime as an external dependency.

The only issue I have, is that setuptools & pip support external dependencies that are not released to PyPI as long as they have a setup.py file (it grabs the source via a git tag). However, isodatetime doesn't have a setup.py file yet.

This pull request contains a simple setup.py file that worked in my environment. Here's the tests I performed:

1. Check out the branch of this pull request
2. In another directory (e.g. /tmp) open `python`, and try `import isodatetime`. You should receive an error `ImportError: No module named isodatetime`
3. Back on the branch folder, run `pip install -e . -v`. That will install the archive locally for development

```
    Adding isodatetime 2018.2.0 to easy-install.pth file

    Installed /home/kinow/Development/python/workspace/isodatetime
Successfully installed isodatetime
Cleaning up...
```

4. Open another terminal in another directory outside the project structure again, and try

```
kinow@localhost:/tmp$ python
Python 2.7.15rc1 (default, Apr 15 2018, 21:51:34) 
[GCC 7.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import isodatetime
>>> isodatetime.__version__
'2018.02.0'
>>> from isodatetime import parsers
>>> parser = parsers.TimePointParser(allow_truncated=True)
>>> parser.parse("1984-01-30T00:00:00Z", "1984-02-30T00:00:00Z")
1984-02-30T00:00:00Z
>>>
```

This tests that pip is able to install the module locally for development, and also that the library appears to be still working. With this, I (and anybody else using this library really) should be able to quickly install it with pip. Assuming you have installed it with pip locally, here's how to uninstall.

```
pip uninstall isodatetime
Uninstalling isodatetime-2018.2.0:
  /home/kinow/.local/lib/python2.7/site-packages/isodatetime.egg-link
Proceed (y/n)? y
  Successfully uninstalled isodatetime-2018.2.0
```

And here's how to test installing it with pip from a Git URL.

```
kinow@localhost:~$ pip install git+git://github.com/kinow/isodatetime.git@add-setup-py#egg=isodatetime
Collecting isodatetime from git+git://github.com/kinow/isodatetime.git@add-setup-py#egg=isodatetime
  Cloning git://github.com/kinow/isodatetime.git (to add-setup-py) to /tmp/pip-build-QOJt7S/isodatetime
Installing collected packages: isodatetime
  Running setup.py install for isodatetime ... done
Successfully installed isodatetime-2018.2.0
kinow@localhost:~$ python
Python 2.7.15rc1 (default, Apr 15 2018, 21:51:34) 
[GCC 7.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import isodatetime
>>> isodatetime.__version__
'2018.02.0'
>>> 
```

Which is basically the same thing I am trying to do in my experiment.

Users should still be able to clone the repository and install locally, of course.

If someone registers this package in PYPI and uses this setup.py file, it should take only a few minutes to get it as a package directly with `pip install isodatetime` :tada: 

Thanks!
Bruno