### PR TITLE
Use decimal for seconds instead of octal

### DIFF
--- a/isodatetime/tests.py
+++ b/isodatetime/tests.py
@@ -84,7 +84,7 @@ def get_timedurationparser_tests():
         "P0004-078": {"years": 4, "days": 78},
         "P0004-078T10,5": {"years": 4, "days": 78, "hours": 10.5},
         "P00000020T133702": {"days": 20, "hours": 13, "minutes": 37,
-                             "seconds": 02},
+                             "seconds": 2},
         "-P3YT4H2M": {"years": -3, "hours": -4, "minutes": -2},
         "-PT5M": {"minutes": -5},
         "-P7Y": {"years": -7, "hours": 0}


### PR DESCRIPTION
Not able to run the tests locally (see #89) so hoping Travis CI will be happy with this change :tada: 

I think the test was supposed to use a decimal and not an octal, but if it is the other way, then I would update this PR to use the 3.x syntax, with `0o2` instead.

Cheers
Bruno