### PR TITLE
Report test coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# (C) British Crown Copyright 2013-2018 Met Office.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------------
+
+# Codecov settings
+# After modifying this file, it might be worth to validate it with:
+# `curl --data-binary @.codecov.yml https://codecov.io/validate`
+
+# which branch to monitor and whether wait for ci success
+codecov:
+  branch: master
+  notify:
+    require_ci_to_pass: yes
+
+# define the colour bar limits here
+coverage:
+  precision: 2
+  round: down
+  range: "75...100"
+
+  # diff type
+  status:
+    project:
+      default:
+        # commits below this threshold will be marked as failed
+        target: '75%'
+        # how much we allow the coverage to drop
+        threshold: '5%'
+    patch:
+      default:
+        # basic
+        target: '75%'
+        threshold: '5%'
+        base: auto
+        # advanced
+        branches: null
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
+        flags: null
+        paths: null
+    changes: no
+
+# files to ignore
+ignore:
+  - "isodatetime/tests.py"
+
+# turn off comments to pull requests
+comment: off

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# (C) British Crown Copyright 2013-2018 Met Office.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------------
+
+
+[run]
+
+branch=True
+cover_pylib=False
+concurrency=thread
+data_file=${TRAVIS_BUILD_DIR}/.coverage
+disable_warnings=
+debug=
+#    callers
+#    dataio
+#    multiprocess
+#    dataio
+#    dataop
+#    pid
+#    plugin
+#    process
+#    sys
+#    trace
+# Include can be used only if source is not used!
+#include
+note=
+omit=
+    */isodatetime/tests*
+parallel = False
+plugins=
+source=
+    ./isodatetime
+timid = False
+
+
+[report]
+
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise NotImplementedError
+    if __name__ == .__main__.:
+    def parse_args
+fail_under=0
+ignore_errors = False
+include=
+omit=
+    */isodatetime/tests*
+partial_branches=
+precision=2
+show_missing=False
+skip_covered=False
+sort=Name
+
+
+[html]
+
+directory=htmlcov
+extra_css=
+title=
+
+
+[xml]
+
+output=coverage.xml
+package_depth=99

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 *.py[co]
 *.swp
+
+# coverage
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,48 @@
 
 ---
 language: python
+
 python:
-    - "2.6"
-    - "2.7"
-install:
-    - pip install pycodestyle
+  - 2.6
+  - 2.7
+env:
+  - RUN_COVERAGE=false
+  - RUN_COVERAGE=true
+
+matrix:
+  fast_finish: true
+  exclude:
+    - python: 2.6
+      env: RUN_COVERAGE=true
+    - python: 2.7
+      env: RUN_COVERAGE=false
+
+before_install:
+  # Coverage dependencies
+  - pip install coverage pytest-cov
+  # Code style dependencies
+  - pip install pycodestyle
 script:
-    - python -m isodatetime.tests
-    - pycodestyle -v isodatetime
+  - |
+    export COVERAGE_PROCESS_START="${TRAVIS_BUILD_DIR}/.coveragerc"
+    # NOTE: the way to handle long-living commands in the documentation is
+    # travis_wait 40 coverage run -m isodatetime.tests
+    # but it does not produce any output, which can be frustrating in case of errors.
+    # So here we are using the approach documented in the issue
+    # https://github.com/travis-ci/travis-ci/issues/4190.
+    coverage run -m isodatetime.tests &
+    minutes=0
+    limit=40
+    while kill -0 $! >/dev/null 2>&1; do
+      echo -n -e " \b" # never leave evidences!
+      if [ $minutes == $limit ]; then
+        break;
+      fi
+      minutes=$((minutes+1))
+      sleep 60
+    done
+after_script:
+  - coverage xml --ignore-errors
+  # Report metrics, such as coverage
+  - '[[ "$RUN_COVERAGE" = true ]] && bash <(curl -s https://codecov.io/bash)'
+  - pycodestyle -v isodatetime

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ isodatetime
 ===========
 
 [![Build Status](https://travis-ci.org/metomi/isodatetime.svg?branch=master)](https://travis-ci.org/metomi/isodatetime)
+[![codecov](https://codecov.io/gh/metomi/isodatetime/branch/master/graph/badge.svg)](https://codecov.io/gh/metomi/isodatetime)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.597555.svg)](https://doi.org/10.5281/zenodo.597555)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/1fd1147b75474d4d9a0f64bececf3bb5)](https://www.codacy.com/app/metomi/isodatetime?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=metomi/isodatetime&amp;utm_campaign=Badge_Grade)
 


### PR DESCRIPTION
In #87 there were a few comments about adding support to Python 3 (while perhaps dropping support to Python 2). So as in Cylc and Rose (still broken, but will revisit it later) this pull request adds coverage reports to the project.

The build time increased significantly due to the way that Coverage.py instruments via Python's trace. The test `test_timerecurrence_parser` which normally takes a while, unfortunately takes a bit more due to the coverage overhead.

I executed the job around 10 times between yesterday and today, locally and in Travis-CI, and the current configuration runs all tests between 28-34 minutes. Here's the latest job output in Travis-CI for my fork.

https://travis-ci.org/kinow/isodatetime

Which is configured with m Codacy integration project API, uploading to my own dashboard for now

https://app.codacy.com/project/kinow/isodatetime/dashboard

Overall number for code coverage for isodatetime right now is an impressive **86%** :clap: :clap: :clap: 

But there are a few files that I would write some tests before porting to Python 3, like

- `timezone.py` has only about half of its code tested - https://app.codacy.com/app/kinow/isodatetime/file/22958614608/coverage
- The __str__ method of most classes are not tested. Easy to cover with a unit test, and even though it's using `.format()` which is less likely to cause issues doing a jump from Py2 to Py3, I think it's still worth writing a short test just to confirm that's not changed after the port
- In `data.py`, the `Duration#to_weeks` method is using a division, which could be different in Py3. So worth covering
- Also in `data.py`, `TimePoint#get` has some division not covered by tests
- And the `TimePoint` class has also some methods for addition with little coverage
- Still in `TimePoint`, now the `__cmp__` method uses `cmp`, which doesn't exist in Py3 if I remember well. Better cover 100% of this method as we could re-use the tests even after breaking that method into multiple methods - if necessary
- Not sure what `_type_checker` does or how it's used, but it appears to be easy to add a few more tests to avoid one of the branches introducing a regression

So maybe before moving the code to Python 3, we could write a few more tests, compare the coverage and issues in Codacy, and then start introducing the changes?

Cheers
Bruno