### PR TITLE
Fix isodatetime for western countries with timezone offsets where minutes are not 0

### DIFF
--- a/isodatetime/timezone.py
+++ b/isodatetime/timezone.py
@@ -28,8 +28,8 @@ def get_local_time_zone():
     if time.localtime().tm_isdst == 1 and time.daylight:
         utc_offset_seconds = -time.altzone
     utc_offset_minutes = (utc_offset_seconds // 60) % 60
-    utc_offset_hours = math.floor(utc_offset_seconds / float(3600)) if utc_offset_seconds > 0 else math.ceil(
-        utc_offset_seconds / float(3600))
+    utc_offset_hours = math.floor(utc_offset_seconds / float(3600)) if \
+        utc_offset_seconds > 0 else math.ceil(utc_offset_seconds / float(3600))
     return int(utc_offset_hours), utc_offset_minutes
 
 

--- a/isodatetime/timezone.py
+++ b/isodatetime/timezone.py
@@ -19,6 +19,7 @@
 """This provides utilities for extracting the local time zone."""
 
 import time
+import math
 
 
 def get_local_time_zone():
@@ -27,8 +28,9 @@ def get_local_time_zone():
     if time.localtime().tm_isdst == 1 and time.daylight:
         utc_offset_seconds = -time.altzone
     utc_offset_minutes = (utc_offset_seconds // 60) % 60
-    utc_offset_hours = utc_offset_seconds // 3600
-    return utc_offset_hours, utc_offset_minutes
+    utc_offset_hours = math.floor(utc_offset_seconds / float(3600)) if utc_offset_seconds > 0 else math.ceil(
+        utc_offset_seconds / float(3600))
+    return int(utc_offset_hours), utc_offset_minutes
 
 
 def get_local_time_zone_format(extended_mode=False, reduced_mode=False):


### PR DESCRIPTION
**TL;DR**: `isodatetime` has an issue with western countries where the timezone offset minutes are not `0`, as it tries to floor something like (`-3.5`), getting `-4`, whereas the expected value would be `-3` (IOW ceiling for negative numbers).

**Longer explanation...** I started writing tests to increase coverage in `isodatetime`, starting by the file with the least coverage (57%), `timezone.py`. You can view the current work-in-progress branch [here](https://github.com/metomi/isodatetime/compare/metomi:b3592fb...kinow:8515fb8#diff-3c122eb8fe5c01379c98005cf7925c1eR1585).

I tried to increase line/branch coverage, but also covering what the functions appear to offer in its contracts. So for both functions in `timezone.py`, namely `get_local_time_zone` and `get_local_time_zone_format`, I tried to use time zones that would cover UTC (using as a synonym for GMT), western and eastern countries.

And since I learned that NZ has two time zones, and one of them with broken minutes (i.e. not `0`), I tried to add tests that would then cover both eastern and western countries with similar cases. For example, for the eastern part, we have Nepal, which uses the timezone `Asia/Kathmandu` `+05:45`, and for the western part, we have Newfoundland and Labrador in Canada, which uses the timezone `America/St_Johns` `-03:30`.

The Nepal timezone is correctly interpreted by `isodatetime`. But for Newfoundland and Labrador (which has `utc_offset_secods = -12600`), `isodatetime` is currently doing

```
utc_offset_hours = utc_offset_seconds // 3600
# i.e.
utc_offset_hours = -12600 // 3600
```

And in Python 2.x, `-12600 // 3600` is equals `-4`, which is the wrong value (**we were expecting `-3`**). This happens because of the floor division in Python 2.x, and the negative numerator `-12600`. In Python 3.x we would get `-3.5`, but that would still be a problem, as we actually want the `ceiling` of that number when negative, and the `floor` when positive.

This pull request has the simplest solution I could think of, that *should* work on Python 2 and Python 3. I wrote this fix in the branch mentioned at the top of this lengthy issue description. And the tests passed. Then I stash/pop'ed, and executed the tests from the master branch, and they worked as well (though parts were not covered).

I think it'd be OK if this is reviewed and - hopefully - merged even if there are no tests. Or if another approach is taken to solve this issue. The tests in my current branch are failing, but will pass once we have the fix and I rebase it. And we should have 100% line/branch coverage, and also covering examples for all possible scenarios for timezones (though saying for timezones is always a challenge...).

Cheers
Bruno





