### PR TITLE
Include TZ for running tests

### DIFF
--- a/isodatetime/run_tests
+++ b/isodatetime/run_tests
@@ -19,4 +19,4 @@
 # Run tests for the ISO 8601 parsing and data model functionality."""
 #-----------------------------------------------------------------------------
 cd "$(dirname "$0")/../"
-python -m isodatetime.tests
+TZ=UTC python -m isodatetime.tests


### PR DESCRIPTION
Tested locally, and with this change I can successfully use the `run_tests` instead of running the same in the command line (also included the environment variable in my IDE to be able to run the tests there)