### PR TITLE
Fix TimePoint dumper behaviour after the TimePoint object has been copied

### DIFF
--- a/isodatetime/data.py
+++ b/isodatetime/data.py
@@ -717,10 +717,10 @@ class TimePoint(object):
         "day_of_year", "day_of_month", "day_of_week",
         "week_of_year", "hour_of_day", "minute_of_hour",
         "second_of_minute", "truncated", "truncated_property",
-        "dump_format", "time_zone"
+        "truncated_dump_format", "dump_format", "time_zone"
     ]
 
-    __slots__ = DATA_ATTRIBUTES + ["truncated_dump_format"]
+    __slots__ = DATA_ATTRIBUTES
 
     def __init__(self, expanded_year_digits=0, year=None, month_of_year=None,
                  week_of_year=None, day_of_year=None, day_of_month=None,

--- a/isodatetime/tests.py
+++ b/isodatetime/tests.py
@@ -1276,6 +1276,14 @@ class TestSuite(unittest.TestCase):
             tz = dumper.get_time_zone(value)
             self.assertEqual(expected, tz)
 
+    def test_timepoint_dumper_after_copy(self):
+        """Test that printing the TimePoint attributes works after it has
+        been copied, see issue #102 for more information"""
+        time_point = data.TimePoint(year=2000, truncated=True,
+                                    truncated_dump_format='CCYY')
+        the_copy = time_point.copy()
+        self.assertEqual(str(time_point), str(the_copy))
+
     def test_timepoint_parser(self):
         """Test the parsing of date/time expressions."""
 


### PR DESCRIPTION
A possible fix for #102 

Simply includes the `truncated_dump_format` to the `DATA_ATTRIBUTES` dict. A test that fails without the change, and works after the change in `data.py`.

Cheers
Bruno