### PR TITLE
Fix for bug in ordinal date and week additon in timepoint

### DIFF
--- a/isodatetime/data.py
+++ b/isodatetime/data.py
@@ -1293,11 +1293,11 @@ class TimePoint(object):
                     new.day_of_month = max_day_in_new_month
             elif new.get_is_ordinal_date():
                 max_days_in_year = get_days_in_year(new.year)
-                if max_days_in_year > new.day_of_year:
+                if max_days_in_year < new.day_of_year:
                     new.day_of_year = max_days_in_year
             elif new.get_is_week_date():
                 max_weeks_in_year = get_weeks_in_year(new.year)
-                if max_weeks_in_year > new.week_of_year:
+                if max_weeks_in_year < new.week_of_year:
                     new.week_of_year = max_weeks_in_year
         return new
 


### PR DESCRIPTION
Closes #105. ">" swapped for "<" in relevant cases to prevent day-of-year always being set to the maximum number of days in the year, and week-of-year always being set to the maximum number of weeks in that year.