### PR TITLE
Addition of test for ordinal date

### DIFF
--- a/isodatetime/data.py
+++ b/isodatetime/data.py
@@ -1119,24 +1119,19 @@ class TimePoint(object):
         if not self.truncated:
             return None
         prop_dict = self.get_truncated_properties()
-        attr_keys = ["year_of_century", "decade_of_century",
-                     "year_of_decade", "month_of_year",
-                     "week_of_year", "day_of_year", "day_of_month",
-                     "day_of_week", "hour_of_day", "minute_of_hour",
-                     "second_of_minute"]
-        attr_dict = {"year_of_century": "century",
-                     "year_of_decade": "decade_of_century",
-                     "month_of_year": "year_of_century",
-                     "week_of_year": "year_of_century",
-                     "day_of_year": "year_of_century",
-                     "day_of_month": "month_of_year",
-                     "day_of_week": "week_of_year",
-                     "hour_of_day": "day_of_month",
-                     "minute_of_hour": "hour_of_day",
-                     "second_of_minute": "minute_of_hour"}
-        for attr in attr_keys:
-            if attr in prop_dict:
-                return attr_dict[attr]
+        attr_list = (("year_of_century", "century"),
+                     ("year_of_decade", "decade_of_century"),
+                     ("month_of_year", "year_of_century"),
+                     ("week_of_year", "year_of_century"),
+                     ("day_of_year", "year_of_century"),
+                     ("day_of_month", "month_of_year"),
+                     ("day_of_week", "week_of_year"),
+                     ("hour_of_day", "day_of_month"),
+                     ("minute_of_hour", "hour_of_day"),
+                     ("second_of_minute", "minute_of_hour"))
+        for attr_key, attr_value in attr_list:
+            if attr_key in prop_dict:
+                return attr_value
         return None
 
     def get_truncated_properties(self):

--- a/isodatetime/data.py
+++ b/isodatetime/data.py
@@ -1293,11 +1293,11 @@ class TimePoint(object):
                     new.day_of_month = max_day_in_new_month
             elif new.get_is_ordinal_date():
                 max_days_in_year = get_days_in_year(new.year)
-                if max_days_in_year < new.day_of_year:
+                if max_days_in_year > new.day_of_year:
                     new.day_of_year = max_days_in_year
             elif new.get_is_week_date():
                 max_weeks_in_year = get_weeks_in_year(new.year)
-                if max_weeks_in_year < new.week_of_year:
+                if max_weeks_in_year > new.week_of_year:
                     new.week_of_year = max_weeks_in_year
         return new
 

--- a/isodatetime/data.py
+++ b/isodatetime/data.py
@@ -1293,11 +1293,11 @@ class TimePoint(object):
                     new.day_of_month = max_day_in_new_month
             elif new.get_is_ordinal_date():
                 max_days_in_year = get_days_in_year(new.year)
-                if max_days_in_year > new.day_of_year:
+                if max_days_in_year < new.day_of_year:
                     new.day_of_year = max_days_in_year
             elif new.get_is_week_date():
                 max_weeks_in_year = get_weeks_in_year(new.year)
-                if max_weeks_in_year > new.week_of_year:
+                if max_weeks_in_year < new.week_of_year:
                     new.week_of_year = max_weeks_in_year
         return new
 

--- a/isodatetime/tests.py
+++ b/isodatetime/tests.py
@@ -427,7 +427,8 @@ def get_timepointparser_tests(allow_only_basic=False,
                 "-W03-1": {"week_of_year": 3, "day_of_week": 1,
                            "truncated": True},
                 "-W32": {"week_of_year": 32, "truncated": True},
-                "-W-1": {"day_of_week": 1, "truncated": True}
+                "-W-1": {"day_of_week": 1, "truncated": True},
+                "-200": {"day_of_year": 200, "truncated": True}
             }
         }
     }
@@ -665,6 +666,9 @@ def get_truncated_property_tests():
         "-W-1": {"day_of_week": 1,
                  "largest_truncated_property_name": "day_of_week",
                  "smallest_missing_property_name": "week_of_year"},
+        "-200": {"day_of_year": 200,
+                 "largest_truncated_property_name": "day_of_year",
+                 "smallest_missing_property_name": "year_of_century"},
         "T04:30": {"hour_of_day": 4,
                    "minute_of_hour": 30,
                    "largest_truncated_property_name": "hour_of_day",


### PR DESCRIPTION
Ordinal date to test added to testing of truncated properties, largest truncated property, and smallest missing property.