### PR TITLE
Add settings to build rpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage.xml
 htmlcov/
 
 # distutils files
+build/
 dist
 MANIFEST
 isodatetime.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ build/
 dist
 MANIFEST
 isodatetime.egg-info/
+python_isodatetime.egg-info/
 .eggs

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ from setuptools import setup
 # https://github.com/pypa/setuptools/issues/308
 from setuptools.extern.packaging import version
 from isodatetime import __version__
+# overriding setuptools command
+# https://stackoverflow.com/a/51294311
+from setuptools.command.bdist_rpm import bdist_rpm as bdist_rpm_original
 
 
 version.Version = version.LegacyVersion
@@ -37,11 +40,21 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
+class bdist_rpm(bdist_rpm_original):
+
+    def run(self):
+        """Before calling the original run method, let's change the
+        distribution name to create an RPM for python-isodatetime."""
+        self.distribution.metadata.name = "python-isodatetime"
+        super().run()
+
+
 setup(
     name="isodatetime",
     version=__version__,
     author="Met Office",
     author_email="metomi@metoffice.gov.uk",
+    cmdclass={"bdist_rpm": bdist_rpm},
     description=("Python ISO 8601 date time parser" +
                  " and data model/manipulation utilities"),
     license="LGPLv3",


### PR DESCRIPTION
Not a requirement for Cylc, but could be useful. The `.gitignore` is to ignore the default build directory. This can also be changed via command line, but I thought simpler to leave the default directory and just ignore it.

The other commit is for adding `setup.cfg`. In this file, the groups of settings represent either commands or special lifecycle stages. So when you run `python setup.py bdist_rpm`, the `bdist_rpm` includes any parameters passed to that command.

For cylc I am including `--requires` to specify what's required for the Cylc RPM. It would be nice if we had something like `python-isodatetime`, so that we could have all dependencies properly managed when installing via `pip` or `rpm`, but that's not a must-have (we can ask users to simply install via `pip` for example).

The installation directory is being hard-coded, as the default value (at least in my environment) was `/usr/local`/, but the CentOS image I had access to was using `/usr/`.

Tested locally (in a comment).