### PR TITLE
Update classifiers and python-requires after Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
     url="https://github.com/metomi/isodatetime",
     packages=['isodatetime'],
     long_description=read('README.md'),
+    long_description_content_type="text/markdown",
     platforms='any',
     install_requires=[],
     python_requires='>=3.4, <3.8',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     long_description=read('README.md'),
     platforms='any',
     install_requires=[],
-    python_requires='>=2.6, <3.0',
+    python_requires='>=3.4, <3.8',
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Other Environment",
@@ -59,7 +59,11 @@ setup(
         ("License :: OSI Approved" +
          " :: GNU Lesser General Public License v3 (LGPLv3)"),
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Utilities"
     ],


### PR DESCRIPTION
Follow-up after #111, the `python-requires` definitely needs `>=3.4`. I've added the `< 3.8` as we were not able to test that in Travis-CI (yet!).

Also tried to update the classifiers accordingly... feel free to suggest different/other classifiers. A complete list can be found here https://pypi.org/pypi?%3Aaction=list_classifiers (good practice to keep them in order as they appear - I think I followed that rule as best as I could).

Cheers
Bruno