### PR TITLE
Check for date type before dumping values

### DIFF
--- a/isodatetime/data.py
+++ b/isodatetime/data.py
@@ -1720,10 +1720,14 @@ class TimePoint(object):
 
         if self.get_is_calendar_date():
             date_string = year_string + "-MM-DD"
-        if self.get_is_ordinal_date():
+        elif self.get_is_ordinal_date():
             date_string = year_string + "-DDD"
-        if self.get_is_week_date():
+        elif self.get_is_week_date():
             date_string = year_string + "-Www-D"
+        else:
+            raise RuntimeError("TimePoint has inconsistent state, points "
+                               "must conform to calendar, ordinal or week "
+                               "dates.")
         time_string = "Thh"
         if self.minute_of_hour is None:
             time_string += ",ii"

--- a/isodatetime/tests/test_00.py
+++ b/isodatetime/tests/test_00.py
@@ -1750,6 +1750,17 @@ class TestSuite(unittest.TestCase):
         t = timepoint + duration
         self.assertEqual(seconds_added, t.second_of_minute)
 
+    def test_timepoint_dump_format(self):
+        """Test the timepoint format dump when values are programmatically
+        set to None"""
+        t = data.TimePoint(year="1984")
+        # commenting out month_of_year here is enough to make the test pass
+        t.month_of_year = None
+        t.day_of_year = None
+        t.week_of_year = None
+        with self.assertRaises(RuntimeError):
+            self.assertEqual("1984-01-01T00:00:00Z", str(t))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Tentative fix for #91. Not the best coming up with exception messages... probably needs some re-wording perhaps? Realized it was doing `if`, `if`, and `if`. But the `if`'s are exclusive, so it could be replaced by `if`/`elif`'s (I believe). Test included.



Cheers
Bruno