### PR TITLE
Small Documentation fixes

### DIFF
--- a/isodatetime/main.py
+++ b/isodatetime/main.py
@@ -280,7 +280,7 @@ def main():
         ],
     ]:
         arg_parser.add_argument(*o_args, **o_kwargs)
-    if hasattr(arg_parse, 'parse_intermixed_args'):
+    if hasattr(arg_parser, 'parse_intermixed_args'):
         args = arg_parser.parse_intermixed_args()
     else:
         args = arg_parser.parse_args()

--- a/isodatetime/main.py
+++ b/isodatetime/main.py
@@ -280,7 +280,10 @@ def main():
         ],
     ]:
         arg_parser.add_argument(*o_args, **o_kwargs)
-    args = arg_parser.parse_args()
+    if hasattr(arg_parse, 'parse_intermixed_args'):
+        args = arg_parser.parse_intermixed_args()
+    else:
+        args = arg_parser.parse_args()
     if args.version_mode:
         print(__version__)
         return


### PR DESCRIPTION
I've removed a few things that have come to light in creating the new wrapper for rose-date:

1. Removed references to -c

2. Added `=` signs to `--offset` options since `--offset -PT2H` doesn't work with Argparse. Apparently Argparse doesn't like anything it doesn't think is a number being passed like this and ISO-Datetime-offsets aren't sufficiently number-like. :disappointed: 

3. Make argparse cope with intermixed args and options (at least at python 3.7). 