### PR TITLE
Use Python 3 typing instead of functions to check types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ before_install:
   - pip install coverage pytest-cov pytest-env pytest-runner
   # Code style dependencies
   - pip install pycodestyle
+  # Python 3.4 needs typing, as it was released with Python 3.5
+  - pip install typing
 before_script:
   - pycodestyle -v isodatetime
 script:

--- a/isodatetime/tests/test_00.py
+++ b/isodatetime/tests/test_00.py
@@ -1753,7 +1753,7 @@ class TestSuite(unittest.TestCase):
     def test_timepoint_dump_format(self):
         """Test the timepoint format dump when values are programmatically
         set to None"""
-        t = data.TimePoint(year="1984")
+        t = data.TimePoint(year=1984)
         # commenting out month_of_year here is enough to make the test pass
         t.month_of_year = None
         t.day_of_year = None


### PR DESCRIPTION
Fixes #110

Instead of using the current type checking functions, in this pull request the parameter received type hints, specifying what possible types are acceptable through `Union[]`. Unit tests and functional tests in Travis passing.

Marked as draft as I have not tested with Cylc or in the Notebooks I had yet :+1: 