### PR TITLE
use parse_intermixed_args in Python versions where this is available

### DIFF
--- a/isodatetime/main.py
+++ b/isodatetime/main.py
@@ -280,7 +280,13 @@ def main():
         ],
     ]:
         arg_parser.add_argument(*o_args, **o_kwargs)
-    args = arg_parser.parse_args()
+
+    # parse_intermixed_args if available
+    if hasattr(arg_parser, 'parse_intermixed_args'):
+        args = arg_parser.parse_intermixed_args()
+    else:
+        args = arg_parser.parse_args()
+
     if args.version_mode:
         print(__version__)
         return


### PR DESCRIPTION
[Whilst upgrading rose date to rely more heavily on isodatetime](https://github.com/metomi/rose/issues/2303) I added the following to increase the flexibility of isodatetime arguments and options.

[WIP] - Needs Tests