### PR TITLE
Support CF compat calendar mode strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,19 @@
 ---
 language: python
 
-python:
-  - 3.4
-  - 3.5
-  - 3.6
-  - 3.7-dev
-env:
-  - TZ=UTC
-
 matrix:
   fast_finish: true
-  exclude:
+  include:
     - python: 3.4
-      env: RUN_COVERAGE=true
+      env: RUN_COVERAGE=false
     - python: 3.5
-      env: RUN_COVERAGE=true
+      env: RUN_COVERAGE=false
     - python: 3.6
       env: RUN_COVERAGE=false
     - python: 3.7-dev
       env: RUN_COVERAGE=true
+    - python: 3.7-dev
+      env: RUN_COVERAGE=false TZ=UTC
 
 before_install:
   # Upgrade pip and setuptools as some times the versioning scheme hack fails

--- a/isodatetime/data.py
+++ b/isodatetime/data.py
@@ -40,19 +40,25 @@ class Calendar(object):
     LEAP_YEAR_FACTOR_TRUTHS = [(4, True), (100, False), (400, True)]
 
     MODE_360 = "360day"
+    MODE_360_DAY = "360_day"
     MODE_365 = "365day"
+    MODE_365_DAY = "365_day"
     MODE_366 = "366day"
+    MODE_366_DAY = "366_day"
     MODE_GREGORIAN = "gregorian"
+    DAYS_IN_MONTHS_360 = 12 * (30,)
+    DAYS_IN_MONTHS_365 = (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+    DAYS_IN_MONTHS_366 = (31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
 
     # {mode: (days_in_months, days_in_months_leap), ...}
     MODES = {
-        MODE_360: (12 * [30], None),
-        MODE_365: ([31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31], None),
-        MODE_366: ([31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31], None),
-        MODE_GREGORIAN: (
-            [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
-            [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
-        ),
+        MODE_360: (DAYS_IN_MONTHS_360, None),
+        MODE_360_DAY: (DAYS_IN_MONTHS_360, None),
+        MODE_365: (DAYS_IN_MONTHS_365, None),
+        MODE_365_DAY: (DAYS_IN_MONTHS_365, None),
+        MODE_366: (DAYS_IN_MONTHS_366, None),
+        MODE_366_DAY: (DAYS_IN_MONTHS_366, None),
+        MODE_GREGORIAN: (DAYS_IN_MONTHS_365, DAYS_IN_MONTHS_366),
     }
 
     WEEK_DAY_START_REFERENCE = {"calendar": (2000, 1, 3),
@@ -2206,6 +2212,7 @@ def get_timepoint_from_seconds_since_unix_epoch(num_seconds):
     """
     reference_timepoint = TimePoint(
         **CALENDAR.UNIX_EPOCH_DATE_TIME_REFERENCE_PROPERTIES)
+    reference_timepoint.set_time_zone_to_local()
     return reference_timepoint + Duration(seconds=float(num_seconds))
 
 

--- a/isodatetime/parsers.py
+++ b/isodatetime/parsers.py
@@ -340,7 +340,7 @@ class TimePointParser(object):
 
     def strptime(self, strptime_data_string, strptime_format_string,
                  dump_format=None):
-        """Implement equivalent of Python 2's datetime.datetime.strptime.
+        """Implement equivalent of Python's datetime.datetime.strptime.
 
         Return an isodatetime.data.TimePoint representing
         strptime_data_string based on the format given in

--- a/isodatetime/tests/test_00.py
+++ b/isodatetime/tests/test_00.py
@@ -1458,6 +1458,7 @@ class TestSuite(unittest.TestCase):
             minute_of_hour=ctrl_date.minute,
             second_of_minute=ctrl_date.second
         )
+        test_date.set_time_zone_to_utc()
         for test_date in [test_date, test_date.copy().to_week_date(),
                           test_date.copy().to_ordinal_date()]:
             ctrl_data = ctrl_date.strftime(strftime_string)
@@ -1474,6 +1475,8 @@ class TestSuite(unittest.TestCase):
                     ctrl_data = datetime.datetime.strptime(
                         ctrl_dump, strptime_string)
                 test_data = parser.strptime(test_dump, strptime_string)
+                if any(s in strptime_string for s in ('%s', '%z')):
+                    test_data.set_time_zone_to_utc()
 
                 ctrl_data = (
                     ctrl_data.year, ctrl_data.month, ctrl_data.day,

--- a/isodatetime/tests/test_datetimeoper.py
+++ b/isodatetime/tests/test_datetimeoper.py
@@ -31,7 +31,7 @@ import isodatetime.datetimeoper
 class TestDateTimeOperator(unittest.TestCase):
     """Test isodatetime.datetimeoper.TestDateTimeOperator functionalities."""
 
-    @patch('isodatetime.datetimeoper.get_timepoint_for_now')
+    @patch('isodatetime.datetimeoper.now2point')
     def test_process_time_point_str_now_0(self, mock_now_func):
         """DateTimeOperator.process_time_point_str()"""
         # 2009-02-13T23:31:30Z
@@ -43,7 +43,7 @@ class TestDateTimeOperator(unittest.TestCase):
             str(mock_now),
             datetimeoper.process_time_point_str(datetimeoper.STR_NOW))
 
-    @patch('isodatetime.datetimeoper.get_timepoint_for_now')
+    @patch('isodatetime.datetimeoper.now2point')
     def test_process_time_point_str_ref_0(self, mock_now_func):
         """DateTimeOperator.process_time_point_str('ref')
 
@@ -175,12 +175,21 @@ class TestDateTimeOperator(unittest.TestCase):
             # 360day
             ('360day', '20130301', ['-P1D'], '20130230'),
             ('360day', '20130230', ['P1D'], '20130301'),
+            # 360_day
+            ('360_day', '20130301', ['-P1D'], '20130230'),
+            ('360_day', '20130230', ['P1D'], '20130301'),
             # 365day
             ('365day', '20130301', ['-P1D'], '20130228'),
             ('365day', '20130228', ['P1D'], '20130301'),
+            # 365_day
+            ('365_day', '20130301', ['-P1D'], '20130228'),
+            ('365_day', '20130228', ['P1D'], '20130301'),
             # 366day
             ('366day', '20130301', ['-P1D'], '20130229'),
             ('366day', '20130229', ['P1D'], '20130301'),
+            # 366_day
+            ('366_day', '20130301', ['-P1D'], '20130229'),
+            ('366_day', '20130229', ['P1D'], '20130301'),
         ]:
             # Calendar mode, is unfortunately, a global variable,
             # so needs to reset value on return.


### PR DESCRIPTION
Alternate calendar mode strings: 360_day, 365_day, 366_day.
Fix local time incompat in tests.

Close #129.