### PR TITLE
Use old project name in setup.py?

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ class bdist_rpm(bdist_rpm_original):
 
 
 setup(
-    name="metomi-isodatetime",
+    name="isodatetime",
     version='1!' + __version__,
     author="Met Office",
     author_email="metomi@metoffice.gov.uk",


### PR DESCRIPTION
Hi,

A pull request with a question :grimacing: Just wondering if the project name was supposed to change with the new project structure/layout?

If so we will need to update the dependency in cylc-flow's `setup.py` and someone will need to reserve the name in PYPI too?

Cheers
Bruno
