### PR TITLE
Update Python version info for package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
     setup_requires=['pytest-runner'],
     tests_require=['coverage', 'pytest>=5', 'pytest-cov', 'pytest-env'],
     install_requires=[],
-    python_requires='>=3.4, <3.8',
+    python_requires='>=3.5, <=3.8',
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Other Environment",
@@ -100,10 +100,10 @@ setup(
         ("License :: OSI Approved" +
          " :: GNU Lesser General Public License v3 (LGPLv3)"),
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Utilities"

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,6 @@ setup(
         "Topic :: Utilities"
     ],
     entry_points={
-        'console_scripts': ['isodatetime=isodatetime.main:main'],
+        'console_scripts': ['isodatetime=metomi.isodatetime.main:main'],
     },
 )


### PR DESCRIPTION
Drop Python 3.4 - no longer tested under Travis CI.
Add Python 3.8 - dev now tested under Travis CI.
Fix console script entry point package.