### PR TITLE
Remove unused os import from setup.py, and fix typos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,7 +73,7 @@ various fixes.
 
 [#106](https://github.com/metomi/isodatetime/pull/106),
 [#108](https://github.com/metomi/isodatetime/pull/108):
-Fix ordinal date and week additon.
+Fix ordinal date and week addition.
 
 [#103](https://github.com/metomi/isodatetime/pull/103):
 Fix `TimePoint` dumper behaviour after the `TimePoint` object has been copied.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ python setup.py install
 Python API:
 
 <!-- GitHub Python syntax highlighting has issues with datetimes, Ruby works
-     resonably well as a standin. -->
+     reasonably well as a stand-in. -->
 ```ruby
 >>> import metomi.isodatetime.parsers as parse
 >>> import metomi.isodatetime.dumpers as dump

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@
 # ----------------------------------------------------------------------------
 
 from importlib.util import spec_from_file_location, module_from_spec
-import os
 from pathlib import Path
 # overriding setuptools command
 # https://stackoverflow.com/a/51294311


### PR DESCRIPTION
Ran a full code inspection in the IDE on the PR to look for Python 3.4 or Python 3.8 incompatibilities, but everything was OK.

It only located one unused import, and a few typos :+1: One review should do?