### PR TITLE
Make pytest_runner an optional dependency of setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,11 @@ class bdist_rpm(bdist_rpm_original):
         self.distribution.metadata.version = __version__
         super().run()
 
+# Only include pytest-runner in setup_requires if we're invoking tests
+if {'pytest', 'test', 'ptr'}.intersection(sys.argv):
+    setup_requires = ['pytest-runner']
+else:
+    setup_requires = []
 
 setup(
     name="metomi-isodatetime",
@@ -88,7 +93,7 @@ setup(
     long_description=open(str(Path(DIST_DIR, 'README.md')), 'r').read(),
     long_description_content_type="text/markdown",
     platforms='any',
-    setup_requires=['pytest-runner'],
+    setup_requires=setup_requires,
     tests_require=['coverage', 'pytest>=5', 'pytest-cov', 'pytest-env'],
     install_requires=[],
     python_requires='>=3.5, <3.9',


### PR DESCRIPTION
This removes the need to specify it as a `host` dependency in the conda recipe.