### PR TITLE
Include LICENSE.txt in sdist and wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,3 +19,6 @@
 [aliases]
 # so that running python setup.py test invokes pytest
 test=pytest
+
+[metadata]
+license_files = LICENSE


### PR DESCRIPTION
Ship license in all cases, this also removes the need to bundle the license with the conda recipe.