### PR TITLE
cli: add option to read from stdin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ install:
   - pip install coverage pytest-cov pytest-env pytest-runner
   # Code style dependencies
   - pip install pycodestyle
+  - pip install -e .
 
 before_script:
   - pycodestyle -v metomi/isodatetime

--- a/metomi/isodatetime/main.py
+++ b/metomi/isodatetime/main.py
@@ -174,8 +174,7 @@ from . import __version__
 from .datetimeoper import DateTimeOperator
 
 
-def main():
-    """Implement "isodatetime" command."""
+def parse_args():
     arg_parser = ArgumentParser(
         prog='isodatetime',
         formatter_class=RawDescriptionHelpFormatter,
@@ -184,7 +183,10 @@ def main():
         [
             ["items"],
             {
-                "help": "Time point, duration or recurrence string",
+                "help": (
+                    "Time point, duration or recurrence string."
+                    " To read from stdin use '-'."
+                ),
                 "metavar": "ITEM",
                 "nargs": "*",
             },
@@ -284,6 +286,12 @@ def main():
         args = arg_parser.parse_intermixed_args()
     else:
         args = arg_parser.parse_args()
+    return args
+
+
+def main():
+    """Implement "isodatetime" command."""
+    args = parse_args()
     if args.version_mode:
         print(__version__)
         return
@@ -292,6 +300,9 @@ def main():
         utc_mode=args.utc_mode,
         calendar_mode=args.calendar,
         ref_point_str=args.ref_point_str)
+
+    if list(args.items) == ['-']:
+        args.items = sys.stdin.read().splitlines()
 
     try:
         if len(args.items) >= 2:

--- a/metomi/isodatetime/tests/test_main.py
+++ b/metomi/isodatetime/tests/test_main.py
@@ -19,10 +19,12 @@
 
 
 import os
+from subprocess import PIPE, Popen, DEVNULL
 import sys
 import unittest
 from unittest.mock import patch
 
+import pytest
 
 import metomi.isodatetime
 import metomi.isodatetime.main as isodatetime_main
@@ -249,6 +251,22 @@ class TestMain(unittest.TestCase):
                 str(ctxmgr.exception))
         finally:
             sys.argv = argv
+
+
+@pytest.mark.parametrize(
+    'stdin,args,stdout', [
+        ('2000', [], '2000'),
+        ('2000\n2001', ['--as-total', 'h'], '8784.0')
+    ]
+)
+def test_pipe(stdin, args, stdout):
+    """Test piping args into the command via stdin."""
+    assert Popen(
+        ['isodatetime', '-'] + args,
+        stdout=PIPE, stdin=PIPE
+    ).communicate(
+        stdin.encode()
+    )[0].decode().strip() == stdout
 
 
 if __name__ == '__main__':

--- a/metomi/isodatetime/tests/test_main.py
+++ b/metomi/isodatetime/tests/test_main.py
@@ -19,7 +19,7 @@
 
 
 import os
-from subprocess import PIPE, Popen, DEVNULL
+from subprocess import PIPE, Popen  # nosec
 import sys
 import unittest
 from unittest.mock import patch
@@ -264,7 +264,7 @@ def test_pipe(stdin, args, stdout):
     assert Popen(
         ['isodatetime', '-'] + args,
         stdout=PIPE, stdin=PIPE
-    ).communicate(
+    ).communicate(  # nosec
         stdin.encode()
     )[0].decode().strip() == stdout
 


### PR DESCRIPTION
Use the `isodatetime` command in pipes:

```console
$ echo 2000 | isodatetime - --format '%Y%m%d'
20000101
```

This makes the `isodatetime` command a useful CLI adapter.

(would have been useful for a test I'm currently writing)