### PR TITLE
Fix missing T in dump when formatting_string has time zone after T

### DIFF
--- a/metomi/isodatetime/dumpers.py
+++ b/metomi/isodatetime/dumpers.py
@@ -167,12 +167,13 @@ class TimePointDumper(object):
     @lru_cache(maxsize=100000)
     def _get_expression_and_properties(self, formatting_string):
         date_time_strings = formatting_string.split(
-            self._time_designator)
+            self._time_designator)  # if no T then hh:mm etc doesn't work
         date_string = date_time_strings[0]
         time_string = ""
         time_zone_string = ""
         custom_time_zone = None
-        if len(date_time_strings) > 1:
+        has_time_string = len(date_time_strings) > 1
+        if has_time_string:
             time_string = date_time_strings[1]
             if time_string.endswith("Z"):
                 time_string = time_string[:-1]
@@ -201,9 +202,9 @@ class TimePointDumper(object):
                 string = new_string
             string_map[key] = string
         expression = string_map["date"]
-        if string_map["time"]:
-            expression += self._time_designator + string_map["time"]
-        expression += string_map["time_zone"]
+        if has_time_string:
+            expression += self._time_designator + string_map["time"] + \
+                string_map["time_zone"]
         return expression, tuple(point_prop_list), custom_time_zone
 
     @lru_cache(maxsize=100000)

--- a/metomi/isodatetime/tests/test_00.py
+++ b/metomi/isodatetime/tests/test_00.py
@@ -159,7 +159,9 @@ def get_timepoint_dumper_tests():
               "+000044-01-04T05:01:02+00:00"),
              ("DD/MM/CCYY is a silly format", "04/01/0044 is a silly format"),
              ("ThhZ", "T05Z"),
-             ("%Y-%m-%dT%H:%M", "0044-01-04T05:01")]
+             ("%Y-%m-%dT%H:%M", "0044-01-04T05:01"),
+             ("CCYYMMDD00.T+3", "0044010400.T+3"),
+             ("T+3", "T+3")]
         ),
         (
             {"year": 500200, "month_of_year": 7, "day_of_month": 28,


### PR DESCRIPTION
Resolve #66 (sort of)