### PR TITLE
Speed up non-coverage test jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,19 @@ before_script:
 
 script:
   - |
-    export COVERAGE_PROCESS_START="${TRAVIS_BUILD_DIR}/.coveragerc"
-    export COVERAGE_FILE="${TRAVIS_BUILD_DIR}/.coverage"
+    if "$RUN_COVERAGE"; then
+      PY_CMD="coverage run"
+      export COVERAGE_PROCESS_START="${TRAVIS_BUILD_DIR}/.coveragerc"
+      export COVERAGE_FILE="${TRAVIS_BUILD_DIR}/.coverage"
+    else
+      PY_CMD="python"
+    fi
     # NOTE: the way to handle long-living commands in the documentation is
     # travis_wait 40 coverage run -m isodatetime.tests.test_time_point
     # but it does not produce any output, which can be frustrating in case of errors.
     # So here we are using the approach documented in the issue
     # https://github.com/travis-ci/travis-ci/issues/4190.
-    coverage run setup.py test --pytest-args='--runslow' &
+    $PY_CMD setup.py test --pytest-args='--runslow' &
     TEST_PID="$!"
     minutes=0
     limit=50
@@ -75,4 +80,4 @@ script:
 after_success:
   - coverage xml --ignore-errors
   # Report metrics, such as coverage
-  - '"${RUN_COVERAGE:-false}" && bash <(curl -s https://codecov.io/bash)'
+  - if "$RUN_COVERAGE"; then bash <(curl -s https://codecov.io/bash); fi;


### PR DESCRIPTION
Only use `coverage run setup.py` for the one `$RUN_COVERAGE == true` job, else just use `python setup.py`.

Approx times in minutes:

| Strategy          | Before | #161 | Now |
| ----------------- | ------ | ---- | --- |
| Ubuntu            | 10     | 25   | 5   |
| Ubuntu + coverage | 10     | 25   | 25  |
| Mac               | 30     | 50   | 20  |

(my previous PR #161 fixed the path of the isodatetime module in `.coveragerc`)

Travis build: https://travis-ci.org/github/metomi/isodatetime/builds/695070797