### PR TITLE
Make data classes hashable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,17 @@ for a full listing of issues for each release.
 
 --------------------------------------------------------------------------------
 
+## isodatetime 2.0.3 (Upcoming, 2020)
+
+This is the 15th release of isodatetime. Requires Python 3.5+.
+
+### Noteworthy Changes
+
+[#165](https://github.com/metomi/isodatetime/pull/165):
+Data classes are now immutable and hashable.
+
+--------------------------------------------------------------------------------
+
 ## isodatetime 2.0.2 (Released 2020-07-01)
 
 This is the 14th release of isodatetime. Requires Python 3.5+.
@@ -29,7 +40,7 @@ This is the 13th release of isodatetime.
 
 This release requires Python 3.5 or above.
 
-Note the major change in namespace from `isodatetime` to `metomi.isodatime`.
+Note the major change in namespace from `isodatetime` to `metomi.isodatetime`.
 
 ### Noteworthy Changes
 

--- a/README.md
+++ b/README.md
@@ -302,11 +302,11 @@ years, months, days, hours, minutes, and seconds are used literally
 #### 1 - Recur with a duration given by the difference between a start date
 and a subsequent date, starting at the start date
 
-Example Syntax           | Example                 | Meaning
- ----------------------- | ----------------------- | ------------------------------------------------------------------
-R/CCYY/CCYY              | R/2010/2014             | Repeat every 4 years, starting at 2010-01-01.
-R/CCYY-MM/CCYY-DDD       | R/2010-01/2012-045      | Repeat every 2 years and 44 days, starting at 2010-01-01
-R5/CCYY-Www-D/CCYY-Www-D | R/2015-W05-2/2015-W07-3 | Repeat every 2 weeks and 1 day, five times, starting at 2015-W05-2
+Example Syntax           | Example                  | Meaning
+ ----------------------- | ------------------------ | ------------------------------------------------------------------
+R/CCYY/CCYY              | R/2010/2014              | Repeat every 4 years, starting at 2010-01-01.
+R/CCYY-MM/CCYY-DDD       | R/2010-01/2012-045       | Repeat every 2 years and 44 days, starting at 2010-01-01
+Rn/CCYY-Www-D/CCYY-Www-D | R5/2015-W05-2/2015-W07-3 | Repeat every 2 weeks and 1 day, five times, starting at 2015-W05-2
 
 #### 2 - Recur with a given duration, starting at a context date-time
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ Python API:
 >>> duration.get_days_and_seconds()
 (365.0, 10800.0)
 >>> date_time + duration
-2001-01-01T03:00:00Z
+<metomi.isodatetime.data.TimePoint: 2001-01-01T03:00:00Z>
 
 # Recurrences
 >>> recurrence = parse.TimeRecurrenceParser().parse('R/1999/P1Y')
 >>> recurrence.get_next(date_time)
-2001-01-01T00:00:00Z
+<metomi.isodatetime.data.TimePoint: 2001-01-01T00:00:00Z>
 
 # Output
 >>> dump.TimePointDumper().strftime(date_time, '%d/%M/%Y %H:%M:%S')

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along
 with this program.  If not, see [GNU licenses](http://www.gnu.org/licenses/).
 
-## ISO8601
+## ISO 8601
 
-[ISO8601 (2004)](https://www.iso.org/standard/40874.html)
+[ISO 8601 (2004)](https://www.iso.org/standard/40874.html)
 is an international standard for writing down date/time information.
 
 It is the correct, internationally-friendly, computer-sortable way to
@@ -277,6 +277,20 @@ Syntax    | Example  | Meaning
 
 Combining any other unit with weeks is not allowed. Decimals may only be used
 for hours, minutes and seconds.
+
+Note that years and months are "nominal" durations, whose exact length of time
+depends on their position in the calendar. E.g., a duration of 1 calendar year
+starts on a particular day of a particular month and ends on the same day of
+the same month in the following calendar year, and may be different to 365 days
+in the Gregorian calendar due to leap years.
+
+Conversely, weeks, days, hours, minutes and seconds are exact units, so
+`P1W == P7D`, `P1D == PT24H` and `PT1H == PT60M` etc. are always true.
+(Although ISO 8601 specifies that weeks and days are nominal durations, there
+is no case where they are not exact in our implementation.)
+<!-- ...because TimePoints always have time zones assigned to them (apart
+from truncated TimePoints, but you can't add Durations to truncated
+TimePoints). Local time zones don't actually exist in our implementation. -->
 
 A supplementary format (which has to be agreed in advance) is to specify a
 date-time-like duration (`PCCYY-MM-DDThh:mm:ss`) where the numbers given for

--- a/README.md
+++ b/README.md
@@ -299,8 +299,7 @@ years, months, days, hours, minutes, and seconds are used literally
 
 ### Recurring date-time series
 
-#### 1 - Recur with a duration given by the difference between a start date
-and a subsequent date, starting at the start date
+#### 1. Recur with a duration given by the difference between a start date and a subsequent date
 
 Example Syntax           | Example                  | Meaning
  ----------------------- | ------------------------ | ------------------------------------------------------------------
@@ -308,7 +307,7 @@ R/CCYY/CCYY              | R/2010/2014              | Repeat every 4 years, star
 R/CCYY-MM/CCYY-DDD       | R/2010-01/2012-045       | Repeat every 2 years and 44 days, starting at 2010-01-01
 Rn/CCYY-Www-D/CCYY-Www-D | R5/2015-W05-2/2015-W07-3 | Repeat every 2 weeks and 1 day, five times, starting at 2015-W05-2
 
-#### 2 - Recur with a given duration, starting at a context date-time
+#### 2. Recur with a specified duration, starting at a context date-time
 
 (You have to supply the context somewhere else)
 
@@ -317,7 +316,7 @@ Example Syntax        | Example          | Meaning
 R/PnMnDTnM            | R/P10M3DT45M     | Repeat every 10 months, 3 days, and 45 minutes from a context start date-time.
 Rn/PnY                | R2/P4Y           | Repeat every 4 years, for a total of 2 times, from a context start date-time.
 
-#### 3 - Recur with a given duration starting at a particular date-time
+#### 3. Recur with a specified duration starting at a particular date-time
 
 Example Syntax             | Example                  | Meaning
  ------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------
@@ -326,14 +325,17 @@ R/CCYY-Www-D/PnW           | R/2012-W02-1/P1W         | Repeat weekly starting a
 R/CCYYDDDThhmm/PnD         | R/1996291T0630+0100/P2D  | Repeat every 2 days starting on the 291st day of 1996 at 06:30, UTC + 1
 Rn/CCYY-MM-DDThh:mm/PTnH   | R2/19900201T06Z/PT12H    | Repeat every 12 hours, for a total of 2 repetitions, starting at 1990-02-01T06Z
 Rn/CCYY-Www-D/PnW          | R5/2012-W02-1/P1W        | Repeat weekly, for a total of 5 repetitions, starting at Monday in the second ISO week of 2012
-Rn/CCYYDDDThhmm/PnD        | R1/1996291T0630+0100/P2D | Repeat once at the 291st day of 1996 at 06:30, UTC + 1
+Rn/CCYYDDDThhmm/PnD        | R1/1996291T0630+0100/P2D | Repeat once at the 291st day of 1996 at 06:30, UTC + 1 (note the duration is ignored)
 
-#### 4 - Recur with a given duration counting back from a particular date-time
+#### 4. Recur with a specified duration ending at a particular date-time
+
+The starting date-time of the recurrence is calculated from the specified
+duration.
 
 Example Syntax             | Example                  | Meaning
  ------------------------- | ------------------------ | ---------------------------------------------------------------
-R/PTnH/CCYY-MM-DDThhZ      | R/PT1H/2012-01-02T00Z    | Repeat hourly counting back from 2012-01-02T00Z
-R/PnY/CCYY                 | R/P3Y/2000               | Repeat every 3 years counting back from 2000-01-01.
-R/PTnS/+XCCYYDDDThhmm      | R/PT5s/-002500012T1800   | Repeat every 5 seconds counting back from the 12th day in 2501 BC at 18:00 (using 2 expanded year digits).
-Rn/PnYTnM/CCYY-MM-DDThhZ   | R5/P1YT5M/2012-01-02T00Z | Repeat every year and 5 minutes counting back from 2012-01-02T00Z
-Rn/PnM/CCYY-MM             | R4/P1M/2000-05           | Repeat monthly, four times, counting back from 2000-05-01.
+R/PTnH/CCYY-MM-DDThhZ      | R/PT1H/2012-01-02T00Z    | Repeat hourly until 2012-01-02T00Z
+R/PnY/CCYY                 | R/P3Y/2000               | Repeat every 3 years until 2000-01-01.
+R/PTnS/+XCCYYDDDThhmm      | R/PT5s/-002500012T1800   | Repeat every 5 seconds until the 12th day in 2501 BC at 18:00 (using 2 expanded year digits).
+Rn/PnYTnM/CCYY-MM-DDThhZ   | R5/P1YT5M/2012-01-02T00Z | Repeat every year and 5 minutes, five times, until 2012-01-02T00Z
+Rn/PnM/CCYY-MM             | R4/P1M/2000-05           | Repeat monthly, four times, until 2000-05-01.

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -377,9 +377,8 @@ class Duration(object):
         self._hours = hours
         self._minutes = minutes
         self._seconds = seconds
-        if (not self.years and not self.months and not self.hours and
-                not self.minutes and not self.seconds and
-                weeks and not days):
+        if (weeks and not years and not months and not days and
+                not hours and not minutes and not seconds):
             self._weeks = self.days // CALENDAR.DAYS_IN_WEEK
             self._years, self._months, self._days = (None, None, None)
             self._hours, self._minutes, self._seconds = (None, None, None)
@@ -569,32 +568,22 @@ class Duration(object):
 
     def __eq__(self, other: "Duration") -> bool:
         # TODO: check instance of other
-        my_data = self.get_days_and_seconds()
-        other_data = other.get_days_and_seconds()
-        return my_data == other_data
+        return self.get_days_and_seconds() == other.get_days_and_seconds()
 
     def __ne__(self, other: "Duration") -> bool:
         return not self.__eq__(other)
 
     def __lt__(self, other: "Duration") -> bool:
-        my_data = self.get_days_and_seconds()
-        other_data = other.get_days_and_seconds()
-        return my_data < other_data
+        return self.get_days_and_seconds() < other.get_days_and_seconds()
 
     def __le__(self, other: "Duration") -> bool:
-        my_data = self.get_days_and_seconds()
-        other_data = other.get_days_and_seconds()
-        return my_data <= other_data
+        return self.get_days_and_seconds() <= other.get_days_and_seconds()
 
     def __gt__(self, other: "Duration") -> bool:
-        my_data = self.get_days_and_seconds()
-        other_data = other.get_days_and_seconds()
-        return my_data > other_data
+        return self.get_days_and_seconds() > other.get_days_and_seconds()
 
     def __ge__(self, other: "Duration") -> bool:
-        my_data = self.get_days_and_seconds()
-        other_data = other.get_days_and_seconds()
-        return my_data >= other_data
+        return self.get_days_and_seconds() >= other.get_days_and_seconds()
 
     def __bool__(self):
         for attr in self.DATA_ATTRIBUTES:
@@ -603,6 +592,9 @@ class Duration(object):
         return False
 
     def __str__(self):
+        if not self:
+            return "P0Y"
+
         start_string = "P"
         content_string = ""
 
@@ -636,10 +628,7 @@ class Duration(object):
             if prop_ == "days":
                 content_string += "T"
 
-        if content_string == "T":
-            # No content, zero duration.
-            content_string = "0Y"
-        elif content_string.endswith("T"):
+        if content_string.endswith("T"):
             # No time unit information, so strip the delimiter.
             content_string = content_string[:-1]
 

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -475,6 +475,8 @@ class Duration:
         This is not rigorous when converting from non-uniform units
         such as years and months.
         """
+        if self.is_exact():
+            return self._get_non_nominal_seconds()
         days, seconds = self.get_days_and_seconds()
         return days * CALENDAR.SECONDS_IN_DAY + seconds
 
@@ -589,6 +591,7 @@ class Duration:
         return new
 
     def __hash__(self) -> int:
+        # TODO: alt calendar modes
         if self.get_is_in_weeks():
             return hash((0, 0, self._get_non_nominal_seconds()))
         return hash((self.years, self.months, self._get_non_nominal_seconds()))
@@ -692,6 +695,9 @@ class Duration:
 
         total_string = start_string + content_string
         return total_string.replace(".", ",")
+
+    def __repr__(self):
+        return "<isodatetime.data.Duration: {0}>".format(repr(str(self)))
 
 
 class TimeZone(Duration):

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -223,6 +223,8 @@ class TimeRecurrence:
         elif self.end_point is None:
             # Third form.
             self._format_number = 3
+            # If repetitions == 1, duration is actually ignored. TODO: Can
+            # probably set to None or something for the purposes of __eq__()
             if self.repetitions is not None:
                 self._end_point = (
                     self.start_point + self.duration * (self.repetitions - 1))
@@ -339,6 +341,21 @@ class TimeRecurrence:
                 point = self.get_prev(point)
             else:
                 point = self.get_next(point)
+
+    def __hash__(self) -> int:
+        # TODO: fix when fixing issue #45
+        return hash((self.repetitions, self.start_point, self.end_point,
+                     self.min_point, self.max_point))
+
+    def __eq__(self, other: "TimeRecurrence") -> bool:
+        if not isinstance(other, TimeRecurrence):
+            return NotImplemented
+        # TODO: fix when fixing issue #45
+        for attr in ["repetitions", "start_point", "end_point", "min_point",
+                     "max_point"]:
+            if getattr(self, attr) != getattr(other, attr):
+                return False
+        return True
 
     def __str__(self):
         if self.repetitions is None:

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -151,8 +151,8 @@ class TimeRecurrence(object):
     max_point
     """
 
-    __slots__ = ("repetitions", "start_point", "duration", "end_point",
-                 "min_point", "max_point", "format_number")
+    __slots__ = ["_repetitions", "_start_point", "_duration", "_end_point",
+                 "_min_point", "_max_point", "_format_number"]
 
     def __init__(self, repetitions=None, start_point=None,
                  duration=None, end_point=None, min_point=None,
@@ -166,19 +166,19 @@ class TimeRecurrence(object):
             (max_point, "max_point", None, TimePoint)
         )
         _type_checker(*inputs)
-        self.repetitions = repetitions
-        self.start_point = start_point
-        self.duration = duration
-        self.end_point = end_point
-        self.min_point = min_point
-        self.max_point = max_point
-        self.format_number = None
+        self._repetitions = repetitions
+        self._start_point = start_point
+        self._duration = duration
+        self._end_point = end_point
+        self._min_point = min_point
+        self._max_point = max_point
+        self._format_number = None
         if self.duration is None:
             # First form.
-            self.format_number = 1
+            self._format_number = 1
             start_year, start_days = self.start_point.get_ordinal_date()
             start_seconds = self.start_point.get_second_of_day()
-            self.end_point = self.end_point.to_time_zone(
+            self._end_point = self.end_point.to_time_zone(
                 self.start_point.time_zone)
             end_year, end_days = self.end_point.get_ordinal_date()
             end_seconds = self.end_point.get_second_of_day()
@@ -193,7 +193,7 @@ class TimeRecurrence(object):
                 diff_days += 1
                 diff_seconds -= CALENDAR.SECONDS_IN_DAY
             if self.repetitions == 1:
-                self.duration = Duration(years=0)
+                self._duration = Duration(years=0)
             else:
                 diff_days_float = diff_days / float(
                     self.repetitions - 1)
@@ -202,25 +202,46 @@ class TimeRecurrence(object):
                 diff_days = int(diff_days_float)
                 diff_seconds_float += (
                     diff_days_float - diff_days) * CALENDAR.SECONDS_IN_DAY
-                self.duration = Duration(
+                self._duration = Duration(
                     days=diff_days, seconds=diff_seconds_float)
         elif self.end_point is None:
             # Third form.
-            self.format_number = 3
+            self._format_number = 3
             if self.repetitions is not None:
-                self.end_point = (
+                self._end_point = (
                     self.start_point + self.duration * (self.repetitions - 1))
         elif self.start_point is None:
             # Fourth form.
-            self.format_number = 4
+            self._format_number = 4
             if self.repetitions is not None:
-                self.start_point = (
+                self._start_point = (
                     self.end_point - self.duration * (self.repetitions - 1))
         else:
             raise BadInputError(
                 BadInputError.RECURRENCE, [i[:2] for i in inputs])
 
-    def get_is_valid(self, timepoint):
+    @property
+    def repetitions(self): return self._repetitions
+
+    @property
+    def start_point(self): return self._start_point
+
+    @property
+    def duration(self): return self._duration
+
+    @property
+    def end_point(self): return self._end_point
+
+    @property
+    def min_point(self): return self._min_point
+
+    @property
+    def max_point(self): return self._max_point
+
+    @property
+    def format_number(self): return self._format_number
+
+    def get_is_valid(self, timepoint: "TimePoint") -> bool:
         """Return whether the timepoint is valid for this recurrence."""
         if not self._get_is_in_bounds(timepoint):
             return False

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -564,6 +564,9 @@ class Duration(object):
         new._seconds //= other
         return new
 
+    def __hash__(self) -> int:
+        return hash(self.get_days_and_seconds())
+
     def __eq__(self, other: "Duration") -> bool:
         # TODO: check instance of other
         my_data = self.get_days_and_seconds()

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -612,38 +612,22 @@ class Duration:
 
     def __lt__(self, other: "Duration") -> bool:
         if isinstance(other, Duration):
-            if not (self.is_exact() and other.is_exact()):
-                return (self.get_days_and_seconds() <
-                        other.get_days_and_seconds())
-            return (self._get_non_nominal_seconds() <
-                    other._get_non_nominal_seconds())
+            return self.get_days_and_seconds() < other.get_days_and_seconds()
         return NotImplemented
 
     def __le__(self, other: "Duration") -> bool:
         if isinstance(other, Duration):
-            if not (self.is_exact() and other.is_exact()):
-                return (self.get_days_and_seconds() <=
-                        other.get_days_and_seconds())
-            return (self._get_non_nominal_seconds() <=
-                    other._get_non_nominal_seconds())
+            return self.get_days_and_seconds() <= other.get_days_and_seconds()
         return NotImplemented
 
     def __gt__(self, other: "Duration") -> bool:
         if isinstance(other, Duration):
-            if not (self.is_exact() and other.is_exact()):
-                return (self.get_days_and_seconds() >
-                        other.get_days_and_seconds())
-            return (self._get_non_nominal_seconds() >
-                    other._get_non_nominal_seconds())
+            return self.get_days_and_seconds() > other.get_days_and_seconds()
         return NotImplemented
 
     def __ge__(self, other: "Duration") -> bool:
         if isinstance(other, Duration):
-            if not (self.is_exact() and other.is_exact()):
-                return (self.get_days_and_seconds() >=
-                        other.get_days_and_seconds())
-            return (self._get_non_nominal_seconds() >=
-                    other._get_non_nominal_seconds())
+            return self.get_days_and_seconds() >= other.get_days_and_seconds()
         return NotImplemented
 
     def __bool__(self):

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -443,14 +443,15 @@ class Duration(object):
         100 will return 1 day, 100 seconds or (1, 100) from this
         method.
         """
+        if self.get_is_in_weeks():
+            return self.weeks * CALENDAR.DAYS_IN_WEEK, 0
         # TODO: Implement error calculation for the below quantities.
-        new = self.to_days()
-        new_days = (new.years * CALENDAR.ROUGH_DAYS_IN_YEAR +
-                    new.months * CALENDAR.ROUGH_DAYS_IN_MONTH +
-                    new.days)
-        new_seconds = (new.hours * CALENDAR.SECONDS_IN_HOUR +
-                       new.minutes * CALENDAR.SECONDS_IN_MINUTE +
-                       new.seconds)
+        new_days = (self.years * CALENDAR.ROUGH_DAYS_IN_YEAR +
+                    self.months * CALENDAR.ROUGH_DAYS_IN_MONTH +
+                    self.days)
+        new_seconds = (self.hours * CALENDAR.SECONDS_IN_HOUR +
+                       self.minutes * CALENDAR.SECONDS_IN_MINUTE +
+                       self.seconds)
         diff_days, new_seconds = divmod(new_seconds, CALENDAR.SECONDS_IN_DAY)
         new_days += diff_days
         return new_days, new_seconds

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -484,6 +484,8 @@ class Duration(object):
     def to_weeks(self):
         """Return a new Duration in week representation (warning: use with
         caution)."""
+        # FIXME - this method loses precision
+        # https://github.com/metomi/isodatetime/issues/166
         if not self.get_is_in_weeks():
             weeks = self.days // CALENDAR.DAYS_IN_WEEK
             return Duration(weeks=weeks)

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -735,7 +735,7 @@ class TimeZone(Duration):
     @property
     def unknown(self): return self._unknown
 
-    def _copy(self):
+    def _copy(self) -> "TimeZone":
         """Return an unlinked copy of this instance."""
         return TimeZone(hours=self.hours, minutes=self.minutes,
                         unknown=self.unknown, _is_copy=True)
@@ -752,10 +752,10 @@ class TimeZone(Duration):
             return time_string % (abs(self.hours), abs(self.minutes))
 
     def __repr__(self):
-        return "<isodatetime.data.TimeZone:" + repr(str(self)) + ">"
+        return "<isodatetime.data.TimeZone: {0}>".format(repr(str(self)))
 
 
-class TimePoint(object):
+class TimePoint:
 
     """Represent an instant in time.
 
@@ -784,57 +784,56 @@ class TimePoint(object):
     expanded_year_digits (default 0) - an agreed-upon number of extra
         digits to represent the year, beyond the default of 4. For example,
         a value of 2 would suggest representing the year 2000 as 002000.
-    year - a positive or negative integer. Note that ISO 8601 implies
+    year (int): A positive or negative integer. Note that ISO 8601 implies
         using non-zero expanded_year_digits when using negative integers.
         Remember we are using the proleptic Gregorian calendar, with a year
         zero which does not exist in standard 1 BC => 1 AD usage - so 2 BC
         should be represented as -1.
-    month_of_year - an integer between 1 and 12 inclusive, if using the
+    month_of_year (int): An integer between 1 and 12 inclusive, if using the
         calendar date representation.
-    week_of_year - an integer between 1 and 52/53 (depending on the
+    week_of_year (int): An integer between 1 and 52/53 (depending on the
         year), if using the week date representation.
-    day_of_year - an integer between 1 and 365/366 (depending on the
+    day_of_year (int): An integer between 1 and 365/366 (depending on the
         year), if using the ordinal date representation.
-    day_of_month - an integer between 1 and 28/29/30/31 (depending on
+    day_of_month (int): An integer between 1 and 28/29/30/31 (depending on
         the month and year), if using the calendar date representation.
-    day_of_week - an integer between 1 and 7, if using the week date
+    day_of_week (int): An integer between 1 and 7, if using the week date
         representation.
-    hour_of_day - an integer between 0 and 24 (note: 24 represents midnight at
-        the end of the day, which is equivalent to 00/midnight the next day. If
-        24 is given, minute_of_hour must be 0)
-    hour_of_day_decimal - a float between 0 and 1, if using decimal
+    hour_of_day (int): An integer between 0 and 24 (note: 24 represents
+        midnight at the end of the day, which is equivalent to 00/midnight
+        the next day. If 24 is given, minute_of_hour must be 0).
+    hour_of_day_decimal (float): A float between 0 and 1, if using decimal
         accuracy for hours. Note that you should not provide lower units
         such as minute_of_hour or second_of_minute when using this.
-    minute_of_hour - an integer between 0 and 59.
-    minute_of_hour_decimal - a float between 0 and 1, if using decimal
+    minute_of_hour (int): An integer between 0 and 59.
+    minute_of_hour_decimal (float): A float between 0 and 1, if using decimal
         accuracy for minutes. Note that you should not provide lower units
         such as second_of_minute when using this.
-    second_of_minute - an integer between 0 and 59 (note: no support
-        for leap seconds at 60 yet)
-    second_of_minute_decimal - a float between 0 and 1, if using decimal
+    second_of_minute (int): An integer between 0 and 59 (note: no support
+        for leap seconds yet).
+    second_of_minute_decimal (float): A float between 0 and 1, if using decimal
         accuracy for seconds.
-    time_zone_hour - (default 0) an integer denoting the hour time zone
-        offset from UTC. Note that unless this is a truncated
-        representation, 0 will be assumed if this is not provided.
-    time_zone_minute - (default 0) an integer between 0 and 59 denoting
-        the minute component of the time zone offset from UTC.
-    dump_format - a custom format string to control the stringification
+    time_zone_hour (int): The hour component of the time zone offset from UTC,
+        between -99 and 99. The default is 0 unless this is a truncated
+        TimePoint.
+    time_zone_minute (int): The minute component of the time zone offset from
+        UTC. If the hour component is negative, this should be negative too.
+    dump_format (str): A custom format string to control the stringification
         of the timepoint. See isodatetime.parser_spec for more details.
-    truncated - (default False) a boolean denoting whether the
-        date/time instant has purposefully incomplete information
-        (ISO 8601:2000 truncation).
-    truncated_dump_format - a custom format string to control the
-        stringification of the timepoint if it is truncated. See
-        isodatetime.parser_spec for more details.
-    truncated_property - a string that can either be "year_of_decade"
-        or "year_of_century". This is used for truncated representations to
+    truncated (bool): Whether the date-time instant has purposefully incomplete
+        information (ISO 8601:2000 truncation). Default is False.
+    truncated_dump_format (str): A custom format to control the stringification
+        of the timepoint if it is truncated. See isodatetime.parser_spec for
+        more details.
+    truncated_property (str): Can either be "year_of_decade" or
+        "year_of_century". This is used for truncated representations to
         distinguish between the two ways of truncating the year.
-    is_empty_instance - if True, do not set any properties yet. These
-        should be set as part of a copy operation.
-    is_duration - for datetime-like durations syntax. If True the datetime
-        will not be checked to make sure values are within bounds, and if the
-        values of month_of_year, day_of_month etc are not supplied they will be
-        assumed to be 0 instead of 1.
+    is_empty_instance (bool): If True, do not set any properties yet. These
+        should be set as part of a copy operation. Default is False.
+    is_duration (bool): For datetime-like durations syntax. If True the
+        args will not be checked to make sure values are within bounds, and if
+        the values of month_of_year, day_of_month etc are not supplied they
+        will be assumed to be 0 instead of 1. Default is False.
     """
 
     DATA_ATTRIBUTES = [
@@ -859,13 +858,12 @@ class TimePoint(object):
         if is_empty_instance:
             # This has been created for a copy - set properties later.
             return
-        if (dump_format is not None and not
-                isinstance(dump_format, str)):
+        if dump_format is not None and not isinstance(dump_format, str):
             raise BadInputError(
                 BadInputError.TYPE,
                 "dump_format", repr(dump_format), type(dump_format))
-        if (truncated_dump_format is not None and not
-                isinstance(truncated_dump_format, str)):
+        if (truncated_dump_format is not None and
+                not isinstance(truncated_dump_format, str)):
             raise BadInputError(
                 BadInputError.TYPE,
                 "truncated_dump_format", repr(truncated_dump_format),
@@ -1199,7 +1197,7 @@ class TimePoint(object):
         second_of_day += self.hour_of_day * CALENDAR.SECONDS_IN_HOUR
         return second_of_day
 
-    def get_time_zone_utc(self):
+    def get_time_zone_utc(self) -> bool:
         # FIXME: Misleading name
         """Return whether the time zone is explicitly in UTC."""
         if self.time_zone.unknown:
@@ -1218,7 +1216,7 @@ class TimePoint(object):
         if self.get_is_week_date():
             return self.year, self.week_of_year, self.day_of_week
 
-    def get_time_zone_offset(self, other):
+    def get_time_zone_offset(self, other: "TimePoint") -> "Duration":
         """Get the difference in hours and minutes between time zones.
 
         Args:
@@ -1229,7 +1227,7 @@ class TimePoint(object):
             return Duration()
         return other.time_zone - self.time_zone
 
-    def to_time_zone(self, dest_time_zone):
+    def to_time_zone(self, dest_time_zone: "TimeZone") -> "TimePoint":
         """Return a copy of this TimePoint in the specified time zone.
 
         Args:
@@ -1241,17 +1239,17 @@ class TimePoint(object):
         new._time_zone = dest_time_zone
         return new
 
-    def to_local_time_zone(self):
+    def to_local_time_zone(self) -> "TimePoint":
         """Return a copy of this TimePoint in the local time zone."""
         local_hours, local_minutes = timezone.get_local_time_zone()
         return self.to_time_zone(
             TimeZone(hours=local_hours, minutes=local_minutes))
 
-    def to_utc(self):
+    def to_utc(self) -> "TimePoint":
         """Return a copy of this TimePoint in the UTC time zone."""
         return self.to_time_zone(TimeZone(hours=0, minutes=0))
 
-    def to_calendar_date(self):
+    def to_calendar_date(self) -> "TimePoint":
         """Return a copy of this TimePoint reformatted in years, month-of-year
         and day-of-month."""
         if self.get_is_calendar_date():
@@ -1263,7 +1261,7 @@ class TimePoint(object):
         new._week_of_year, new._day_of_week = (None, None)
         return new
 
-    def to_hour_minute_second(self):
+    def to_hour_minute_second(self) -> "TimePoint":
         """Return a copy of this TimePoint with any time fractions expanded
         into hours, minutes and seconds."""
         new = self._copy()
@@ -1271,7 +1269,7 @@ class TimePoint(object):
             self.get_hour_minute_second())
         return new
 
-    def to_week_date(self):
+    def to_week_date(self) -> "TimePoint":
         """Return a copy of this TimePoint reformatted in years, week-of-year
         and day-of-week."""
         if self.get_is_week_date():
@@ -1282,7 +1280,7 @@ class TimePoint(object):
         new._month_of_year, new._day_of_month = (None, None)
         return new
 
-    def to_ordinal_date(self):
+    def to_ordinal_date(self) -> "TimePoint":
         """Return a copy of this TimePoint reformatted in years and
         day-of-the-year."""
         new = self._copy()
@@ -1305,8 +1303,7 @@ class TimePoint(object):
         return None
 
     def get_smallest_missing_property_name(self):
-        """Return the smallest unit missing
-        from a truncated representation."""
+        """Return the smallest unit missing from a truncated representation."""
         if not self.truncated:
             return None
         prop_dict = self.get_truncated_properties()
@@ -1407,7 +1404,7 @@ class TimePoint(object):
                 new_year_of_century = new.year % 100
         return new
 
-    def __add__(self, other):
+    def __add__(self, other) -> "TimePoint":
         if isinstance(other, TimePoint):
             if self.truncated and not other.truncated:
                 new = other.to_time_zone(self.time_zone)
@@ -1479,7 +1476,7 @@ class TimePoint(object):
                     new._week_of_year = max_weeks_in_year
         return new
 
-    def _copy(self):
+    def _copy(self) -> "TimePoint":
         """Returns an unlinked copy of this instance."""
         new_timepoint = TimePoint(is_empty_instance=True)
         for attr in self.DATA_ATTRIBUTES:
@@ -1487,8 +1484,8 @@ class TimePoint(object):
         new_timepoint._time_zone = self.time_zone._copy()
         return new_timepoint
 
-    def get_props(self):
-        """Return the data properties of this TimePoint."""
+    def get_props(self) -> list:
+        """Return the data properties of this TimePoint as a list of tuples."""
         props = []
         for attr in self.DATA_ATTRIBUTES:
             value = getattr(self, attr, None)
@@ -1918,7 +1915,6 @@ class TimePoint(object):
         """Implement equivalent of Python 2's datetime.datetime.strftime.
 
         Dump based on the format given in the strftime_format string.
-
         """
         return self.__str__(strftime_format=strftime_format)
 

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -146,8 +146,8 @@ class TimeRecurrence:
     2. (Not supported) Recur with a specified duration, starting at some
         context date-time specified elsewhere.
     3. Recur with a specified duration starting at a particular date-time.
-    4. Recur with a specified duration counting back from a particular
-        date-time.
+    4. Recur with a specified duration ending at a particular date-time (the
+        starting date-time is calculated from the duration).
 
     The format of the TimeRecurrence instance is automatically chosen from the
     arguments supplied.

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -483,10 +483,9 @@ class Duration(object):
         return self
 
     def to_weeks(self):
-        """Return a new Duration in week representation (warning: use with
-        caution)."""
-        # FIXME - this method loses precision
-        # https://github.com/metomi/isodatetime/issues/166
+        """Return a new Duration in week representation (use with caution -
+        this returns the floor of the decimal number of weeks, so might lose
+        precision)."""
         if not self.get_is_in_weeks():
             weeks = self.days // CALENDAR.DAYS_IN_WEEK
             return Duration(weeks=weeks)

--- a/metomi/isodatetime/datetimeoper.py
+++ b/metomi/isodatetime/datetimeoper.py
@@ -126,8 +126,7 @@ class DateTimeOperator(object):
         if time_point_str == self.STR_REF:
             time_point_str = self.ref_point_str
         if time_point_str is None or time_point_str == self.STR_NOW:
-            time_point = now2point()
-            time_point.set_time_zone_to_local()
+            time_point = now2point().to_local_time_zone()
             if self.utc_mode or time_point.get_time_zone_utc():  # is in UTC
                 parse_format = self.CURRENT_TIME_DUMP_FORMAT_Z
             else:
@@ -149,7 +148,7 @@ class DateTimeOperator(object):
                     dump_as_parsed=True)
                 parse_format = time_point.dump_format
         if self.utc_mode:
-            time_point.set_time_zone_to_utc()
+            time_point = time_point.to_utc()
         return time_point, parse_format
 
     def date_shift(self, time_point, offset=None):
@@ -249,7 +248,7 @@ class DateTimeOperator(object):
     @staticmethod
     def get_datetime_strftime(time_point, print_format):
         """Use the datetime library's strftime as a fallback."""
-        calendar_date = time_point.copy().to_calendar_date()
+        calendar_date = time_point.to_calendar_date()
         year, month, day = calendar_date.get_calendar_date()
         hour, minute, second = time_point.get_hour_minute_second()
         microsecond = int(1.0e6 * (second - int(second)))

--- a/metomi/isodatetime/dumpers.py
+++ b/metomi/isodatetime/dumpers.py
@@ -126,25 +126,22 @@ class TimePointDumper(object):
                         "day_of_month" in properties or
                         "day_of_year" in properties):
                     # We need the year to be in week years.
-                    timepoint = timepoint.copy().to_week_date()
+                    timepoint = timepoint.to_week_date()
             elif (timepoint.get_is_week_date() and (
                     "month_of_year" in properties or
                     "day_of_month" in properties or
                     "day_of_year" in properties)):
                 # We need the year to be in standard calendar years.
-                timepoint = timepoint.copy().to_calendar_date()
+                timepoint = timepoint.to_calendar_date()
 
         if custom_time_zone is not None:
-            timepoint = timepoint.copy()
             if custom_time_zone == (0, 0):
-                timepoint.set_time_zone_to_utc()
+                timepoint = timepoint.to_utc()
             else:
-                current_time_zone = timepoint.get_time_zone()
-                new_time_zone = current_time_zone.copy()
-                new_time_zone.hours = custom_time_zone[0]
-                new_time_zone.minutes = custom_time_zone[1]
-                new_time_zone.unknown = False
-                timepoint.set_time_zone(new_time_zone)
+                from .data import TimeZone
+                new_time_zone = TimeZone(hours=custom_time_zone[0],
+                                         minutes=custom_time_zone[1])
+                timepoint = timepoint.to_time_zone(new_time_zone)
         property_map = {}
         for property_ in properties:
             property_map[property_] = timepoint.get(property_)

--- a/metomi/isodatetime/tests/test_00.py
+++ b/metomi/isodatetime/tests/test_00.py
@@ -592,10 +592,7 @@ def get_timepointparser_tests(allow_only_basic=False,
 
 
 def get_truncated_property_tests():
-    """
-    Tests for largest truncated and
-    smallest missing property names
-    """
+    """Tests for largest truncated and smallest missing property names."""
     test_timepoints = {
         "-9001": {"year": 90,
                   "month_of_year": 1,
@@ -966,42 +963,32 @@ class TestSuite(unittest.TestCase):
 
     def test_timepoint_time_zone(self):
         """Test the time zone handling of timepoint instances."""
-        year = 2000
-        month_of_year = 1
-        day_of_month = 1
+        year, month_of_year, day_of_month = (2000, 1, 1)
         utc_offset_hours, utc_offset_minutes = (
             get_local_time_zone_hours_minutes()
         )
         for hour_of_day in range(24):
             for minute_of_hour in [0, 30]:
+                point = data.TimePoint(year=year, month_of_year=month_of_year,
+                                       day_of_month=day_of_month,
+                                       hour_of_day=hour_of_day,
+                                       minute_of_hour=minute_of_hour)
                 test_dates = [
-                    data.TimePoint(
-                        year=year,
-                        month_of_year=month_of_year,
-                        day_of_month=day_of_month,
-                        hour_of_day=hour_of_day,
-                        minute_of_hour=minute_of_hour
-                    )
+                    point.to_utc(),
+                    point.to_local_time_zone(),
+                    point.to_time_zone(data.TimeZone(hours=-13, minutes=-45)),
+                    point.to_time_zone(data.TimeZone(hours=8, minutes=30))
                 ]
-                test_dates.append(test_dates[0]._copy())
-                test_dates.append(test_dates[0]._copy())
-                test_dates.append(test_dates[0]._copy())
-                test_dates[0] = test_dates[0].to_utc()
                 self.assertEqual(test_dates[0].time_zone.hours, 0,
                                  test_dates[0])
                 self.assertEqual(test_dates[0].time_zone.minutes, 0,
                                  test_dates[0])
-                test_dates[1] = test_dates[1].to_local_time_zone()
+
                 self.assertEqual(test_dates[1].time_zone.hours,
                                  utc_offset_hours, test_dates[1])
-
                 self.assertEqual(test_dates[1].time_zone.minutes,
                                  utc_offset_minutes, test_dates[1])
-                test_dates[2] = test_dates[2].to_time_zone(
-                    data.TimeZone(hours=-13, minutes=-45))
 
-                test_dates[3] = test_dates[3].to_time_zone(
-                    data.TimeZone(hours=8, minutes=30))
                 for i_test_date in list(test_dates):
                     i_test_date_str = str(i_test_date)
                     date_no_tz = i_test_date._copy()
@@ -1026,6 +1013,7 @@ class TestSuite(unittest.TestCase):
                         self.assertEqual(
                             duration, data.Duration(days=0),
                             i_test_date_str + " - " + j_test_date_str)
+        # TODO: test truncated TimePoints
 
     def test_timepoint_dumper(self):
         """Test the dumping of TimePoint instances."""
@@ -1067,6 +1055,7 @@ class TestSuite(unittest.TestCase):
         the_error = TimePointDumperBoundsError("TimePoint1", "year",
                                                10, 20)
         the_string = the_error.__str__()
+        # FIXME:
         self.assertTrue("TimePoint1" in the_string,
                         "Failed to find TimePoint1 in {}".format(the_string))
         self.assertTrue("year" in the_string,
@@ -1434,7 +1423,6 @@ class TestSuite(unittest.TestCase):
     # the format for the parameters is
     # [tz_seconds, tz_format_mode, expected_format]
     get_test_get_local_time_zone_format = [
-        # UTC
         # UTC, returns Z, flags are never used for UTC
         [0, timezone.TimeZoneFormatMode.normal, "Z"],
         # Positive values, some with minutes != 0

--- a/metomi/isodatetime/tests/test_00.py
+++ b/metomi/isodatetime/tests/test_00.py
@@ -983,29 +983,29 @@ class TestSuite(unittest.TestCase):
                         minute_of_hour=minute_of_hour
                     )
                 ]
-                test_dates.append(test_dates[0].copy())
-                test_dates.append(test_dates[0].copy())
-                test_dates.append(test_dates[0].copy())
-                test_dates[0].set_time_zone_to_utc()
+                test_dates.append(test_dates[0]._copy())
+                test_dates.append(test_dates[0]._copy())
+                test_dates.append(test_dates[0]._copy())
+                test_dates[0] = test_dates[0].to_utc()
                 self.assertEqual(test_dates[0].time_zone.hours, 0,
                                  test_dates[0])
                 self.assertEqual(test_dates[0].time_zone.minutes, 0,
                                  test_dates[0])
-                test_dates[1].set_time_zone_to_local()
+                test_dates[1] = test_dates[1].to_local_time_zone()
                 self.assertEqual(test_dates[1].time_zone.hours,
                                  utc_offset_hours, test_dates[1])
 
                 self.assertEqual(test_dates[1].time_zone.minutes,
                                  utc_offset_minutes, test_dates[1])
-                test_dates[2].set_time_zone(
+                test_dates[2] = test_dates[2].to_time_zone(
                     data.TimeZone(hours=-13, minutes=-45))
 
-                test_dates[3].set_time_zone(
+                test_dates[3] = test_dates[3].to_time_zone(
                     data.TimeZone(hours=8, minutes=30))
                 for i_test_date in list(test_dates):
                     i_test_date_str = str(i_test_date)
-                    date_no_tz = i_test_date.copy()
-                    date_no_tz.time_zone = data.TimeZone(hours=0, minutes=0)
+                    date_no_tz = i_test_date._copy()
+                    date_no_tz._time_zone = data.TimeZone(hours=0, minutes=0)
                     if (i_test_date.time_zone.hours >= 0 or
                             i_test_date.time_zone.minutes >= 0):
                         utc_offset = date_no_tz - i_test_date
@@ -1059,7 +1059,7 @@ class TestSuite(unittest.TestCase):
                 self.assertRaises(ctrl_exception, dumper.dump,
                                   ctrl_timepoint, format_)
         value_error_timepoint = data.TimePoint(minute_of_hour=10)
-        value_error_timepoint.minute_of_hour = "1O"
+        value_error_timepoint._minute_of_hour = "1O"
         self.assertRaises(ValueError, dumper.dump, value_error_timepoint, "%M")
 
     def test_timepoint_dumper_bounds_error_message(self):
@@ -1102,7 +1102,7 @@ class TestSuite(unittest.TestCase):
         been copied, see issue #102 for more information"""
         time_point = data.TimePoint(year=2000, truncated=True,
                                     truncated_dump_format='CCYY')
-        the_copy = time_point.copy()
+        the_copy = time_point._copy()
         self.assertEqual(str(time_point), str(the_copy))
 
     def test_timepoint_parser(self):
@@ -1212,10 +1212,10 @@ class TestSuite(unittest.TestCase):
             minute_of_hour=ctrl_date.minute,
             second_of_minute=ctrl_date.second
         )
-        test_date.set_time_zone_to_utc()
+        # test_date = test_date.to_utc()
 
-        for test_date in [test_date, test_date.copy().to_week_date(),
-                          test_date.copy().to_ordinal_date()]:
+        for test_date in [test_date, test_date.to_week_date(),
+                          test_date.to_ordinal_date()]:
             # Test strftime (dumping):
             ctrl_data = ctrl_date.strftime(strftime_string)
             test_data = test_date.strftime(strftime_string)
@@ -1235,7 +1235,7 @@ class TestSuite(unittest.TestCase):
                         ctrl_dump, strptime_string)
                 test_dump = test_date.strftime(strptime_string)
                 test_data = parser.strptime(test_dump, strptime_string)
-                test_data.set_time_zone_to_utc()
+                test_data = test_data.to_utc()
 
                 self.assertEqual(test_dump, ctrl_dump, strptime_string)
 
@@ -1488,11 +1488,12 @@ class TestSuite(unittest.TestCase):
     def test_timepoint_dump_format(self):
         """Test the timepoint format dump when values are programmatically
         set to None"""
+        # TODO: Get rid of this now that TimePoint is immutable?
         t = data.TimePoint(year="1984")
         # commenting out month_of_year here is enough to make the test pass
-        t.month_of_year = None
-        t.day_of_year = None
-        t.week_of_year = None
+        t._month_of_year = None
+        t._day_of_year = None
+        t._week_of_year = None
         with self.assertRaises(RuntimeError):
             self.assertEqual("1984-01-01T00:00:00Z", str(t))
         # QUESTION: What was this test meant to do exactly?

--- a/metomi/isodatetime/tests/test_01.py
+++ b/metomi/isodatetime/tests/test_01.py
@@ -314,8 +314,7 @@ class TestDataModel(unittest.TestCase):
     def test_duration_to_weeks(self):
         """Test that the duration does not lose precision when converted
         from days"""
-        duration_in_days = data.Duration(days=365)
-        duration_in_days.to_weeks()
+        duration_in_days = data.Duration(days=365).to_weeks()
         duration_in_weeks = data.Duration(weeks=52)
         self.assertEqual(duration_in_days.weeks, duration_in_weeks.weeks)
 

--- a/metomi/isodatetime/tests/test_01.py
+++ b/metomi/isodatetime/tests/test_01.py
@@ -416,10 +416,10 @@ class TestDataModel(unittest.TestCase):
         dur = data.Duration(weeks=4)
         self.assertEqual(dur.get_is_in_weeks(), True)
 
-        for kwarg, expected_days in [  # 2 units of each property + 4 weeks
-                ("years", 758), ("months", 88), ("days", 30),
+        for kwarg, expected_days in [  # 1 unit of each property + 4 weeks
+                ("years", 365 + 28), ("months", 30 + 28), ("days", 1 + 28),
                 ("hours", 28), ("minutes", 28), ("seconds", 28)]:
-            dur = data.Duration(weeks=4, **{kwarg: 2})
+            dur = data.Duration(weeks=4, **{kwarg: 1})
             self.assertFalse(dur.get_is_in_weeks())
             self.assertIsNone(dur.weeks)
             self.assertEqual(dur.get_days_and_seconds()[0], expected_days)
@@ -462,6 +462,11 @@ class TestDataModel(unittest.TestCase):
                     self.assertIs(hash(lhs) == hash(rhs), expected["forward"],
                                   "hash of {0} == hash of {1}"
                                   .format(rhs, lhs))
+
+        # for var in [7, 'foo', (1, 2), data.TimePoint(year=2000)]:
+        #     self.assertFalse(data.Duration(days=1) == var)
+        #     with self.assertRaises(TypeError):
+        #         data.Duration(days=1) < var
 
     def test_timeduration_add_week(self):
         """Test the Duration not in weeks add Duration in weeks."""

--- a/metomi/isodatetime/tests/test_01.py
+++ b/metomi/isodatetime/tests/test_01.py
@@ -302,8 +302,8 @@ def get_timepoint_bounds_tests():
             {"year": 2019, "hour_of_day": 24},
             {"year": 2019, "time_zone_hour": 99},
             {"year": 2019, "time_zone_hour": 0, "time_zone_minute": -1},
+            {"year": 2019, "time_zone_hour": 0, "time_zone_minute": 1},
             {"year": 2019, "time_zone_hour": -1, "time_zone_minute": -1},
-            {"year": 2019, "time_zone_hour": -1, "time_zone_minute": 1},
         ],
         "out_of_bounds": [
             {"year": 2019, "month_of_year": 0},
@@ -350,7 +350,8 @@ def get_timepoint_bounds_tests():
             {"year": 2019, "time_zone_hour": 100},
             {"year": 2019, "time_zone_hour": 0, "time_zone_minute": -60},
             {"year": 2019, "time_zone_hour": 1, "time_zone_minute": -1},
-            {"year": 2019, "time_zone_hour": 1, "time_zone_minute": 60}
+            {"year": 2019, "time_zone_hour": 1, "time_zone_minute": 60},
+            {"year": 2019, "time_zone_hour": -1, "time_zone_minute": 1}
         ]
     }
 

--- a/metomi/isodatetime/tests/test_01.py
+++ b/metomi/isodatetime/tests/test_01.py
@@ -92,6 +92,9 @@ def get_duration_subtract_tests():
 def get_duration_comparison_tests():
     """Yield tests for executing comparison operators on Durations.
 
+    All True "==" tests will be carried out for "<=" & ">= too. Likewise
+    all True "<" & "> tests will be carried out for "<=" & ">=" respectively.
+
     Tuple format --> test:
     (args1, args2, bool1 [, bool2]) -->
         Duration(**args1) <operator> Duration(**args2) is bool1
@@ -115,8 +118,9 @@ def get_duration_comparison_tests():
             ({"months": 1, "days": 7}, {"weeks": 1}, False),
             # Non-nominal/exact durations of different types equal:
             ({"weeks": 1}, {"days": 7}, True),
-            ({"weeks": 1}, {"hours": 168}, True),
+            ({"weeks": 1}, {"hours": 7 * 24}, True),
             ({"days": 1}, {"hours": 24}, True),
+            ({"days": 1}, {"seconds": 24 * 60 * 60}, True),
             ({"hours": 1}, {"minutes": 60}, True),
             ({"hours": 1}, {"minutes": 30, "seconds": 30 * 60}, True),
             ({"hours": 1.5}, {"minutes": 90}, True)
@@ -130,29 +134,22 @@ def get_duration_comparison_tests():
             # Durations of different type:
             ({"years": 1}, {"months": 12}, False, True),
             ({"years": 1}, {"months": 12, "days": 10}, True, False),
+            ({"years": 1}, {"days": 364}, False, True),
             ({"years": 1}, {"days": 365}, False),
             ({"years": 1}, {"days": 366}, True, False),
+            ({"months": 1}, {"days": 29}, False, True),
             ({"months": 1}, {"days": 30}, False),
             ({"months": 1}, {"days": 31}, True, False),
+            ({"weeks": 1}, {"days": 6}, False, True),
             ({"weeks": 1}, {"days": 7}, False),
             ({"weeks": 1}, {"days": 8}, True, False),
+            ({"days": 1}, {"seconds": 24 * 60 * 60 - 1}, False, True),
             ({"days": 1}, {"seconds": 24 * 60 * 60}, False),
             ({"days": 1}, {"seconds": 24 * 60 * 60 + 1}, True, False),
         ],
         "<=": [
-            # Durations of same type:
-            *[({prop: 1}, {prop: 1}, True) for prop in nominal_units],
-            *[({prop: 1}, {prop: 2}, True, False) for prop in nominal_units],
-            # Durations of different type:
-            ({"years": 1}, {"months": 12}, False, True),
-            ({"years": 1}, {"days": 364}, False, True),
             ({"years": 1}, {"days": 365}, True),
-            ({"months": 1}, {"days": 29}, False, True),
             ({"months": 1}, {"days": 30}, True),
-            ({"weeks": 1}, {"days": 6}, False, True),
-            ({"weeks": 1}, {"days": 7}, True),
-            ({"days": 1}, {"seconds": 24 * 60 * 60 - 1}, False, True),
-            ({"days": 1}, {"seconds": 24 * 60 * 60}, True),
         ],
         ">": [
             # Durations of same type:
@@ -162,29 +159,20 @@ def get_duration_comparison_tests():
             ({"years": 1}, {"months": 12}, True, False),
             ({"years": 1}, {"days": 364}, True, False),
             ({"years": 1}, {"days": 365}, False),
+            ({"years": 1}, {"days": 366}, False, True),
             ({"months": 1}, {"days": 29}, True, False),
             ({"months": 1}, {"days": 30}, False),
+            ({"months": 1}, {"days": 31}, False, True),
             ({"weeks": 1}, {"days": 6}, True, False),
             ({"weeks": 1}, {"days": 7}, False),
+            ({"weeks": 1}, {"days": 8}, False, True),
             ({"days": 1}, {"seconds": 24 * 60 * 60 - 1}, True, False),
             ({"days": 1}, {"seconds": 24 * 60 * 60}, False),
+            ({"days": 1}, {"seconds": 24 * 60 * 60 + 1}, False, True),
         ],
         ">=": [
-            # Durations of same type:
-            *[({prop: 1}, {prop: 1}, True) for prop in nominal_units],
-            *[(dur, dur, True) for dur in [
-                {"years": 1, "months": 1, "days": 1}]],
-            *[({prop: 2}, {prop: 1}, True, False) for prop in nominal_units],
-            # Durations of different type:
-            ({"years": 1}, {"months": 12}, True, False),
             ({"years": 1}, {"days": 365}, True),
-            ({"years": 1}, {"days": 366}, False, True),
             ({"months": 1}, {"days": 30}, True),
-            ({"months": 1}, {"days": 31}, False, True),
-            ({"weeks": 1}, {"days": 7}, True),
-            ({"weeks": 1}, {"days": 8}, False, True),
-            ({"days": 1}, {"seconds": 24 * 60 * 60}, True),
-            ({"days": 1}, {"seconds": 24 * 60 * 60 + 1}, False, True),
         ]
     }
 
@@ -288,6 +276,98 @@ def get_timepoint_subtract_tests():
     ]
 
 
+def get_timepoint_comparison_tests():
+    """Yield tests for executing comparison operators on TimePoints.
+
+    All True "==" tests will be carried out for "<=" & ">= too. Likewise
+    all True "<" & "> tests will be carried out for "<=" & ">=" respectively.
+
+    Tuple format --> test:
+    (args1, args2, bool1 [, bool2]) -->
+        TimePoint(**args1) <operator> TimePoint(**args2) is bool1
+    & the reverse:
+        TimePoint(**args2) <operator> TimePoint(**args1) is bool2 if
+            bool2 supplied else bool1
+    """
+    base_YMD = {"year": 2020, "month_of_year": 3, "day_of_month": 14}
+    trunc = {"truncated": True}
+    return {
+        "==": [
+            (base_YMD, base_YMD, True),
+            ({"year": 2020, "month_of_year": 2, "day_of_month": 5},
+             {"year": 2020, "day_of_year": 36},
+             True),
+            ({"year": 2019, "month_of_year": 12, "day_of_month": 30},
+             {"year": 2020, "week_of_year": 1, "day_of_week": 1},
+             True),
+            ({"year": 2019, "day_of_year": 364},
+             {"year": 2020, "week_of_year": 1, "day_of_week": 1},
+             True),
+            ({**base_YMD, "hour_of_day": 9, "time_zone_hour": 0},
+             {**base_YMD, "hour_of_day": 11, "minute_of_hour": 30,
+              "time_zone_hour": 2, "time_zone_minute": 30},
+             True),
+            ({"month_of_year": 3, "day_of_month": 14, **trunc},
+             {"month_of_year": 3, "day_of_month": 14, **trunc},
+             True),
+            # Truncated datetimes of different modes can't be equal:
+            ({"month_of_year": 2, "day_of_month": 5, **trunc},
+             {"day_of_year": 36, **trunc},
+             False),
+            ({"month_of_year": 12, "day_of_month": 30, **trunc},
+             {"week_of_year": 1, "day_of_week": 1, **trunc},
+             False),
+            ({"day_of_year": 364, **trunc},
+             {"week_of_year": 1, "day_of_week": 1, **trunc},
+             False)
+            # TODO: test equal truncated datetimes with different timezones
+            # when not buggy
+        ],
+        "<": [
+            (base_YMD, base_YMD, False),
+            ({"year": 2019}, {"year": 2020}, True, False),
+            ({"year": -1}, {"year": 1}, True, False),
+            ({"year": 2020, "month_of_year": 2},
+             {"year": 2020, "month_of_year": 3},
+             True, False),
+            ({"year": 2020, "month_of_year": 2, "day_of_month": 5},
+             {"year": 2020, "month_of_year": 2, "day_of_month": 6},
+             True, False),
+            ({**base_YMD, "hour_of_day": 9}, {**base_YMD, "hour_of_day": 10},
+             True, False),
+            ({**base_YMD, "hour_of_day": 9, "time_zone_hour": 0},
+             {**base_YMD, "hour_of_day": 7, "time_zone_hour": -3},
+             True, False),
+            ({"day_of_month": 3, **trunc}, {"day_of_month": 4, **trunc},
+             True, False),
+            ({"month_of_year": 1, "day_of_month": 3, **trunc},
+             {"month_of_year": 1, "day_of_month": 4, **trunc},
+             True, False)
+        ],
+        ">": [
+            (base_YMD, base_YMD, False),
+            ({"year": 2019}, {"year": 2020}, False, True),
+            ({"year": -1}, {"year": 1}, False, True),
+            ({"year": 2020, "month_of_year": 2},
+             {"year": 2020, "month_of_year": 3},
+             False, True),
+            ({"year": 2020, "month_of_year": 2, "day_of_month": 5},
+             {"year": 2020, "month_of_year": 2, "day_of_month": 6},
+             False, True),
+            ({**base_YMD, "hour_of_day": 9}, {**base_YMD, "hour_of_day": 10},
+             False, True),
+            ({**base_YMD, "hour_of_day": 9, "time_zone_hour": 0},
+             {**base_YMD, "hour_of_day": 7, "time_zone_hour": -3},
+             False, True),
+            ({"day_of_month": 3, **trunc}, {"day_of_month": 4, **trunc},
+             False, True),
+            ({"month_of_year": 1, "day_of_month": 3, **trunc},
+             {"month_of_year": 1, "day_of_month": 4, **trunc},
+             False, True)
+        ]
+    }
+
+
 def get_timepoint_bounds_tests():
     """Yield tests for checking out of bounds TimePoints."""
     return {
@@ -372,6 +452,60 @@ def get_timepoint_conflicting_input_tests():
     ]
 
 
+def run_comparison_tests(data_class, test_cases):
+    """
+    Args:
+        data_class: E.g. Duration or TimePoint
+        test_cases (dict): Of the form {"==": [...], "<": [...], ...}
+    """
+    for op in test_cases:
+        for case in test_cases[op]:
+            lhs = data_class(**case[0])
+            rhs = data_class(**case[1])
+            expected = {"forward": case[2],
+                        "reverse": case[3] if len(case) == 4 else case[2]}
+            if op == "==":
+                tests = [
+                    {"op": "==", "forward": lhs == rhs, "reverse": rhs == lhs}]
+                if True in expected.values():
+                    tests.append({"op": "<=", "forward": lhs <= rhs,
+                                  "reverse": rhs <= lhs})
+                    tests.append({"op": ">=", "forward": lhs >= rhs,
+                                  "reverse": rhs >= lhs})
+            if op == "<":
+                tests = [
+                    {"op": "<", "forward": lhs < rhs, "reverse": rhs < lhs}]
+                if True in expected.values():
+                    tests.append({"op": "<=", "forward": lhs <= rhs,
+                                  "reverse": rhs <= lhs})
+            if op == "<=":
+                tests = [
+                    {"op": "<=", "forward": lhs <= rhs, "reverse": rhs <= lhs}]
+            if op == ">":
+                tests = [
+                    {"op": ">", "forward": lhs > rhs, "reverse": rhs > lhs}]
+                if True in expected.values():
+                    tests.append({"op": ">=", "forward": lhs >= rhs,
+                                  "reverse": rhs >= lhs})
+            if op == ">=":
+                tests = [
+                    {"op": ">=", "forward": lhs >= rhs, "reverse": rhs >= lhs}]
+
+            for test in tests:
+                assert test["forward"] is expected["forward"], (
+                    "{0} {1} {2}".format(lhs, test["op"], rhs))
+                assert test["reverse"] is expected["reverse"], (
+                    "{0} {1} {2}".format(rhs, test["op"], lhs))
+
+            if op == "==":
+                test = lhs != rhs
+                assert test is not expected["forward"], (
+                    "{0} != {1}".format(lhs, rhs))
+                test = hash(lhs) == hash(rhs)
+                assert test is expected["forward"], (
+                    "hash of {0} == hash of {1}".format(rhs, lhs))
+
+
 class TestDataModel(unittest.TestCase):
     """Test the functionality of data model manipulation."""
 
@@ -438,36 +572,12 @@ class TestDataModel(unittest.TestCase):
 
     def test_duration_comparison(self):
         """Test the Duration rich comparison methods and hashing."""
-        tests = get_duration_comparison_tests()
-        for op in tests:
-            for case in tests[op]:
-                lhs = data.Duration(**case[0])
-                rhs = data.Duration(**case[1])
-                expected = {"forward": case[2],
-                            "reverse": case[3] if len(case) == 4 else case[2]}
-                if op == "==":
-                    test = {"forward": lhs == rhs, "reverse": rhs == lhs}
-                if op == "<":
-                    test = {"forward": lhs < rhs, "reverse": rhs < lhs}
-                if op == "<=":
-                    test = {"forward": lhs <= rhs, "reverse": rhs <= lhs}
-                if op == ">":
-                    test = {"forward": lhs > rhs, "reverse": rhs > lhs}
-                if op == ">=":
-                    test = {"forward": lhs >= rhs, "reverse": rhs >= lhs}
-                self.assertIs(test["forward"], expected["forward"],
-                              "{0} {1} {2}".format(lhs, op, rhs))
-                self.assertIs(test["reverse"], expected["reverse"],
-                              "{0} {1} {2}".format(rhs, op, lhs))
-                if op == "==":
-                    self.assertIs(hash(lhs) == hash(rhs), expected["forward"],
-                                  "hash of {0} == hash of {1}"
-                                  .format(rhs, lhs))
-
-        # for var in [7, 'foo', (1, 2), data.TimePoint(year=2000)]:
-        #     self.assertFalse(data.Duration(days=1) == var)
-        #     with self.assertRaises(TypeError):
-        #         data.Duration(days=1) < var
+        run_comparison_tests(data.Duration, get_duration_comparison_tests())
+        dur = data.Duration(days=1)
+        for var in [7, 'foo', (1, 2), data.TimePoint(year=2000)]:
+            self.assertFalse(dur == var)
+            with self.assertRaises(TypeError):
+                dur < var
 
     def test_timeduration_add_week(self):
         """Test the Duration not in weeks add Duration in weeks."""
@@ -499,8 +609,23 @@ class TestDataModel(unittest.TestCase):
             test_duration = data.Duration(**test["duration"])
             end_point = data.TimePoint(**test["result"])
             test_subtract = (start_point - test_duration).to_calendar_date()
-            self.assertEqual(str(test_subtract), str(end_point),
+            self.assertEqual(test_subtract, end_point,
                              "%s - %s" % (start_point, test_duration))
+
+    def test_timepoint_comparison(self):
+        """Test the TimePoint rich comparison methods and hashing."""
+        run_comparison_tests(data.TimePoint, get_timepoint_comparison_tests())
+        point = data.TimePoint(year=2000)
+        for var in [7, 'foo', (1, 2), data.Duration(days=1)]:
+            self.assertFalse(point == var)
+            with self.assertRaises(TypeError):
+                point < var
+        # Cannot use "<", ">=" etc truncated TimePoints of different modes:
+        day_month_point = data.TimePoint(month_of_year=2, day_of_month=5,
+                                         truncated=True)
+        ordinal_point = data.TimePoint(day_of_year=36, truncated=True)
+        with self.assertRaises(TypeError):  # TODO: should be ValueError?
+            day_month_point < ordinal_point
 
     def test_timepoint_plus_float_time_duration_day_of_month_type(self):
         """Test (TimePoint + Duration).day_of_month is an int."""

--- a/metomi/isodatetime/tests/test_01.py
+++ b/metomi/isodatetime/tests/test_01.py
@@ -325,12 +325,9 @@ class TestDataModel(unittest.TestCase):
             self.assertEqual(dur.get_days_and_seconds()[0], expected_days)
 
     def test_duration_to_weeks(self):
-        """Test that the Duration does not lose precision when converted
-        from days"""
-        # FIXME - it does lose precision!
-        # https://github.com/metomi/isodatetime/issues/166
+        """Test converting Duration in days to Duration in weeks"""
         duration_in_days = data.Duration(days=365).to_weeks()
-        duration_in_weeks = data.Duration(weeks=52)
+        duration_in_weeks = data.Duration(weeks=52)  # 364 days (!)
         self.assertEqual(duration_in_days.weeks, duration_in_weeks.weeks)
 
     def test_duration_to_days(self):

--- a/metomi/isodatetime/tests/test_01.py
+++ b/metomi/isodatetime/tests/test_01.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pragma pylint: disable=pointless-statement
 # ----------------------------------------------------------------------------
 # Copyright (C) British Crown (Met Office) & Contributors.
 #


### PR DESCRIPTION
Close #162 (plus #166 and #50).

As noted in the discussion below, for the hash of two instances to be the same, the `==` operator has to evaluate as True. This is tricky for `Duration`s with nominal units, as `P1Y != P365D` (explained in #167).

The behaviour settled on, which is not ideal, is to have `P1Y` tacitly equal to 365 days (or rather `CALENDAR.ROUGH_DAYS_IN_YEAR`) for the sake of the `<`, `<=`, `>` etc operators (this behaviour is pretty much unchanged from before), but not actually explicitly equal when it comes to `==`.