### PR TITLE
Durations: do not allow decimals for years, months, weeks, days

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ isodatetime R/2000/P1Y --max 3
 [ISO8601 (2004)](https://www.iso.org/standard/40874.html)
 is an international standard for writing down date/time information.
 
-It is the correct, internationally-friendly, computer-sortable way to 
+It is the correct, internationally-friendly, computer-sortable way to
 numerically represent date/time information.
 
 Good reading material:
@@ -95,9 +95,9 @@ Reference material:
 
 #### How do I write the year, month-of-year, and day-of-month down?
 
-Syntax      | Example   
- ---------- | ----------    
- CCYYMMDD    | 20151231   
+Syntax      | Example
+ ---------- | ----------
+ CCYYMMDD    | 20151231
  CCYY-MM-DD  | 2015-12-31
 
 #### How about writing down the year, week-of-year, and day-of-week?
@@ -169,8 +169,8 @@ Syntax             | Example
 
 Write the time after the date, separated with a `T`:
 
-Syntax              | Example   
- ------------------ | ------------------- 
+Syntax              | Example
+ ------------------ | -------------------
  CCYYMMDDThhmmss     | 20151231T063101
  CCYY-MM-DDThh:mm:ss | 2015-12-31T06:31:01
  CCYYWwwDThhmmss     | 2015W534T063101
@@ -180,15 +180,15 @@ Syntax              | Example
 
 #### What about just the hour and minute at a date?
 
-Syntax           | Example 
- --------------- | ----------------    
+Syntax           | Example
+ --------------- | ----------------
  CCYYWwwDThhmm    | 2015W534T0631
  CCYY-Www-DThh:mm | 2015-W53-4T06:31
 
 #### What about just the hour at a date?
 
-Syntax           | Example   
- --------------- | -------------   
+Syntax           | Example
+ --------------- | -------------
  CCYYMMDDThh      | 20151231T06
  CCYY-MM-DDThh    | 2015-12-31T06
 
@@ -252,14 +252,15 @@ to delimit time from date:
 Syntax    | Example  | Meaning
  -------- | -------- | ------------------------
  PnY      |  P2Y     | 2 years
- Pn,oY    |  P5,5Y   | 5 and a half years
- Pn.oY    |  P5.5Y   | 5 and a half years
  PTnM     |  PT7M    | 7 minutes (note the 'T')
  PnM      |  P10M    | 10 months
  PnDTnH   |  P5DT6H  | 5 days and 6 hours
+ PTn,oH   |  PT5,5H  | 5 and a half hours
+ PTn.oH   |  PT5.5H  | 5 and a half hours
  PnW      |  P2W     | 2 weeks
- 
-Combining any other unit with weeks is not allowed.
+
+Combining any other unit with weeks is not allowed. Decimals may only be used
+for hours, minutes and seconds.
 
 A supplementary format (which has to be agreed in advance) is to specify a
 date-time-like duration (`PCCYY-MM-DDThh:mm:ss`) where the numbers given for

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -2322,9 +2322,8 @@ def get_timepoint_from_seconds_since_unix_epoch(num_seconds, utc=False):
         **CALENDAR.UNIX_EPOCH_DATE_TIME_REFERENCE_PROPERTIES)
     reference_timepoint.set_time_zone_to_local()
     if utc:
-        adj_secs = reference_timepoint.time_zone.get_seconds()
+        num_seconds += reference_timepoint.time_zone.get_seconds()
         reference_timepoint.set_time_zone_to_utc()
-        reference_timepoint += Duration(seconds=adj_secs)
     return reference_timepoint + Duration(seconds=float(num_seconds))
 
 

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -320,24 +320,33 @@ class Duration(object):
 
     """Represent a duration or period of time.
 
+    Note that years, months, weeks and days are 'nominal' durations, whose
+    exact length of time depends on their position in the calendar. E.g., a
+    duration of 1 calendar year starts on a particular day of a particular
+    month and ends on the same day of the same month in the following calendar
+    year, and may be equal to 365 or 366 days in the Gregorian calendar.
+    Another example: a duration of 1 calendar day starts at a particular time
+    of day and ends at the same time of day the following calendar day, and
+    might be different to 24 hours if the you're using a local time zone that
+    can change due to daylight saving.
+
     Keyword arguments:
 
-    years (default 0): number of calendar years in the duration (an
-        inexact unit)
-    months (default 0): number of calendar months in the duration (also
-        an inexact unit)
-    weeks (default 0): number of weeks in the duration - cannot be
-        used in conjunction with other units (use multiples of 7 days
-        instead)
-    days (default 0): number of days in the duration
-    hours (default 0): number of hours in the duration
-    minutes (default 0): number of minutes in the duration
-    seconds (default 0): number of seconds in the duration
-    standardize (default False): boolean that, if True, switches on
-        adjusting the attributes so that small units have minimal values.
-        For example, 3664.4 seconds would become 1 hour, 1 minute, and 4.4
-        seconds. Attributes will not adjust for units that are inexact
-        (months and years).
+    years (int): number of calendar years in the duration (an inexact unit
+        due to the possibility of leap years).
+    months (int) number of calendar months in the duration (also an inexact
+        unit due to the differing number of calendar days in the calendar
+        months).
+    weeks (int): number of calendar weeks in the duration - cannot be used in
+        conjunction with other units (use multiples of 7 days instead).
+    days (int): number of calendar days in the duration.
+    hours (float): number of hours in the duration.
+    minutes (float): number of minutes in the duration.
+    seconds (float): number of seconds in the duration.
+    standardize (bool): if True, switches on adjusting the attributes so that
+        small units have minimal values. For example, 3664.4 seconds would
+        become 1 hour, 1 minute, and 4.4 seconds. Attributes will not adjust
+        for units that are inexact (months and years).
     """
 
     DATA_ATTRIBUTES = [
@@ -348,10 +357,10 @@ class Duration(object):
     def __init__(self, years=0, months=0, weeks=0, days=0,
                  hours=0.0, minutes=0.0, seconds=0.0, standardize=False):
         _type_checker(
-            (years, "years", int, float, None),
-            (months, "months", int, float, None),
-            (weeks, "weeks", int, float, None),
-            (days, "days", int, float, None),
+            (years, "years", int, None),
+            (months, "months", int, None),
+            (weeks, "weeks", int, None),
+            (days, "days", int, None),
             (hours, "hours", int, float, None),
             (minutes, "minutes", int, float, None),
             (seconds, "seconds", int, float, None)

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -2301,29 +2301,32 @@ def _get_ordinal_date_week_date_start(year, _):
             return cal_year, total_days
 
 
-def get_timepoint_for_now():
-    """Return a TimePoint at the current date/time."""
+def get_timepoint_for_now(utc=False):
+    """Return a TimePoint at the current date/time.
+
+     Args:
+        utc (bool): Whether the returned TimePoint should be in UTC or the
+            local time zone.
+    """
     import time
-    return get_timepoint_from_seconds_since_unix_epoch(time.time())
+    return get_timepoint_from_seconds_since_unix_epoch(time.time(), utc=utc)
 
 
 def get_timepoint_from_seconds_since_unix_epoch(num_seconds, utc=False):
     """Return a TimePoint at a date/time specified in Unix time.
 
     Args:
-        num_seconds - The number of seconds since the Unix epoch
-        utc (bool) - Whether the returned TimePoint should be in UTC or the
-            local time zone
+        num_seconds (float): The number of seconds since the Unix epoch.
+        utc (bool): Whether the returned TimePoint should be in UTC or the
+            local time zone.
 
     Note that Unix time always counts 1 day = 86400 seconds, so if
     we implement leap seconds we need to make the distinction.
     """
     reference_timepoint = TimePoint(
         **CALENDAR.UNIX_EPOCH_DATE_TIME_REFERENCE_PROPERTIES)
-    reference_timepoint.set_time_zone_to_local()
-    if utc:
-        num_seconds += reference_timepoint.time_zone.get_seconds()
-        reference_timepoint.set_time_zone_to_utc()
+    if not utc:
+        reference_timepoint.set_time_zone_to_local()
     return reference_timepoint + Duration(seconds=float(num_seconds))
 
 

--- a/metomi/isodatetime/datetimeoper.py
+++ b/metomi/isodatetime/datetimeoper.py
@@ -21,10 +21,8 @@ from datetime import datetime
 import os
 import time
 
-from .data import (
-    Calendar,
-    get_timepoint_for_now as now2point,
-    get_timepoint_from_seconds_since_unix_epoch as seconds2point)
+from .data import (Calendar, TimePoint,
+                   get_timepoint_for_now as now2point)
 from .dumpers import TimePointDumper
 from .parsers import TimePointParser, DurationParser, TimeRecurrenceParser
 from metomi.isodatetime.exceptions import OffsetValueError
@@ -264,14 +262,16 @@ class DateTimeOperator(object):
 
     def get_datetime_strptime(self, time_point_str, parse_format):
         """Use the datetime library's strptime as a fallback."""
-        point = seconds2point(
-            time.mktime(time.strptime(time_point_str, parse_format)),
-            utc=True)
+        _time = time.strptime(time_point_str, parse_format)
         # NOTE: Neither time.strptime nor datetime.datetime.strptime can
         # cope with %Z (time zone) that isn't 'UTC' or 'GMT'. There is no
         # way to differentiate between an unrecognised zone (e.g. CET) and
         # a bad time_point_str
-        return point
+        return TimePoint(
+            year=_time.tm_year, month_of_year=_time.tm_mon,
+            day_of_month=_time.tm_mday, hour_of_day=_time.tm_hour,
+            minute_of_hour=_time.tm_min, second_of_minute=_time.tm_sec
+        )
 
     def process_time_point_str(
         self,

--- a/metomi/isodatetime/tests/test_01.py
+++ b/metomi/isodatetime/tests/test_01.py
@@ -301,6 +301,16 @@ class TestDataModel(unittest.TestCase):
                 "%s -> %s(%s)" % (test_props, method, method_args)
             )
 
+    def test_duration_float_args(self):
+        """Test that floats passed to Duration() init are handled correctly."""
+        for kwarg in ["years", "months", "weeks", "days"]:
+            with self.assertRaises(BadInputError):
+                data.Duration(**{kwarg: 1.5})
+        for kwarg, expected_secs in [("hours", 5400), ("minutes", 90),
+                                     ("seconds", 1.5)]:
+            self.assertEqual(data.Duration(**{kwarg: 1.5}).get_seconds(),
+                             expected_secs)
+
     def test_duration_to_weeks(self):
         """Test that the duration does not lose precision when converted
         from days"""


### PR DESCRIPTION
Close #147 

Years, months, weeks and days are nominal durations, which depend on their position in the calendar, unlike time durations (hours, mins, secs). A year is not necessarily equal to 365 or 366 days; instead it is the duration that starts at a particular time on a particular day of a particular month, and ends at the same time of the same day of the same month in the following calendar year.

Even 1 day is not necessarily equal to 24 hours if we are using a local time zone, due to the possibility of a daylight saving change. Instead 1 day is the duration that starts at a particular time of day and ends at the same time of day on the following calendar day.

It follows that decimals of these nominal durations are not easily defined. In order to define 0.5 years it seems you would have to calculate the number of hours between the start date and the same date a year later, then halve that number of hours.

We haven't actually implemented decimals for these nominal durations anyway, but up until now you could pass floats to them when initialising a `Duration`.

Sorry, that ended up a bit long. Rant over 😄 