### PR TITLE
Automatically update copyright year every Jan 1st

### DIFF
--- a/.github/workflows/update_copyright.yml
+++ b/.github/workflows/update_copyright.yml
@@ -1,0 +1,51 @@
+name: Update copyright year
+
+on:
+  schedule:
+    - cron: '0 12 1 1 *' # Every Jan 1st @ 12:00 UTC
+
+jobs:
+  update-copyright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2.3.1
+
+    - name: Configure git
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        year=$(date '+%Y' --utc)
+        branch_name="copyright-${year}"
+        git checkout -b "$branch_name"
+
+        echo "::set-env name=YEAR::$year"
+        echo "::set-env name=BRANCH_NAME::$branch_name"
+
+    - name: Update copyright year
+      run: |
+        pattern="(<span actions:bind='current-year'>).*(<\/span>)"
+        sed -i -E "s/${pattern}/\1${YEAR}\2/" README.md
+
+    - name: Commit & push
+      run : |
+        git commit -a -m "Update copyright year" -m "Workflow: ${{ github.workflow }}, run: ${{ github.run_number }}"
+        git push origin "$BRANCH_NAME"
+
+    - name: Create pull request
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        curl -X POST \
+          https://api.github.com/repos/${{ github.repository }}/pulls \
+          -H "authorization: Bearer ${GH_TOKEN}" \
+          -H 'content-type: application/json' \
+          --data '{
+            "title": "Auto PR: update copyright year",
+            "head": "${{ env.BRANCH_NAME }}",
+            "base": "master",
+            "body": "Happy new year!"
+          }'
+

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ $ isodatetime R/2000/P1Y --max 3
 
 ## Copyright and Terms of Use
 
-Copyright (C) 2013-2020 British Crown (Met Office) & Contributors.
+Copyright (C) 2013-<span actions:bind='current-year'>2020</span> British Crown
+(Met Office) & Contributors.
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free


### PR DESCRIPTION
These changes partially address #171 

This GitHub Actions workflow will create a PR with the updated copyright year in README.md at 12:00 UTC every new year's day.

This sort of workflow also serves as a proof-of-concept for other automation to be addressed from #171 

Demo:
- The workflow: https://github.com/MetRonnie/spork/runs/843244544?check_suite_focus=true
- The PR it created: https://github.com/MetRonnie/spork/pull/5