### PR TITLE
Improve TimeRecurrence class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   - pip install -e .[all]
 
 before_script:
-  - flake8 -v metomi/isodatetime
+  - flake8 metomi/isodatetime
 
 script:
   - |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,11 @@ This is the 15th release of isodatetime. Requires Python 3.5+.
 [#165](https://github.com/metomi/isodatetime/pull/165):
 Data classes are now immutable and hashable.
 
+[#183](https://github.com/metomi/isodatetime/pull/183):
+**Fixed a longstanding mistake in the implementation of TimeRecurrence format
+number 1.** Also implemented support for adding/subtracting Duration instances
+to/from TimeRecurrence instances.
+
 --------------------------------------------------------------------------------
 
 ## isodatetime 2.0.2 (Released 2020-07-01)

--- a/README.md
+++ b/README.md
@@ -336,8 +336,8 @@ duration.
 
 Example Syntax             | Example                  | Meaning
  ------------------------- | ------------------------ | ---------------------------------------------------------------
-R/PTnH/CCYY-MM-DDThhZ      | R/PT1H/2012-01-02T00Z    | Repeat hourly, on the hour, ending at 2012-01-02T00Z
-R/PnY/CCYY                 | R/P3Y/2000               | Repeat every 3 years, on January 1st, ending at 2000-01-01
+R/PTnH/CCYY-MM-DDThhZ      | R/PT1H/2012-01-02T00Z    | Repeat hourly, ending at 2012-01-02T00Z (therefore repeats on the hour)
+R/PnY/CCYY                 | R/P3Y/2000               | Repeat every 3 years, ending at 2000-01-01 (therefore repeats at 00:00 January 1st)
 R/PTnS/+XCCYYDDDThhmm      | R/PT5s/-002500012T1800   | Repeat every 5 seconds, ending on the 12th day in 2501 BC at 18:00 (using 2 expanded year digits)
 Rn/PnYTnM/CCYY-MM-DDThhZ   | R5/P1YT5M/2012-01-02T00Z | Repeat every year and 5 minutes, five times, ending at 2012-01-02T00Z
-Rn/PnM/CCYY-MM             | R4/P1M/2000-05           | Repeat monthly, on the first of the month, four times, ending at 2000-05-01
+Rn/PnM/CCYY-MM             | R4/P1M/2000-05           | Repeat monthly, four times, ending at 2000-05-01 (therefore repeats on the first of the month)

--- a/README.md
+++ b/README.md
@@ -302,11 +302,12 @@ years, months, days, hours, minutes, and seconds are used literally
 
 #### 1. Recur with a duration given by the difference between a start date and a subsequent date
 
-Example Syntax           | Example                  | Meaning
- ----------------------- | ------------------------ | ------------------------------------------------------------------
-R/CCYY/CCYY              | R/2010/2014              | Repeat every 4 years, starting at 2010-01-01.
-R/CCYY-MM/CCYY-DDD       | R/2010-01/2012-045       | Repeat every 2 years and 44 days, starting at 2010-01-01
-Rn/CCYY-Www-D/CCYY-Www-D | R5/2015-W05-2/2015-W07-3 | Repeat every 2 weeks and 1 day, five times, starting at 2015-W05-2
+Example Syntax                 | Example                          | Meaning
+ ----------------------------- | -------------------------------- | ------------------------------------------------------------------
+R/CCYY/CCYY                    | R/2010/2014                      | Repeat every 4 years, starting at 2010-01-01
+R/CCYY-MM/CCYY-DDD             | R/2010-01/2012-045               | Repeat every 2 years and 44 days, starting at 2010-01-01
+Rn/CCYY-Www-D/CCYY-Www-D       | R5/2015-W05-2/2015-W07-3         | Repeat every 2 weeks and 1 day, five times, starting at 2015-W05-2
+Rn/CCYY-MM-DDThh/CCYY-MM-DDThh | R1/1925-02-11T00Z/2027-06-01T00Z | Repeat once at 1925-02-11T00Z (note the end date-time is ignored)
 
 #### 2. Recur with a specified duration, starting at a context date-time
 
@@ -326,7 +327,7 @@ R/CCYY-Www-D/PnW           | R/2012-W02-1/P1W         | Repeat weekly starting a
 R/CCYYDDDThhmm/PnD         | R/1996291T0630+0100/P2D  | Repeat every 2 days starting on the 291st day of 1996 at 06:30, UTC + 1
 Rn/CCYY-MM-DDThh:mm/PTnH   | R2/19900201T06Z/PT12H    | Repeat every 12 hours, for a total of 2 repetitions, starting at 1990-02-01T06Z
 Rn/CCYY-Www-D/PnW          | R5/2012-W02-1/P1W        | Repeat weekly, for a total of 5 repetitions, starting at Monday in the second ISO week of 2012
-Rn/CCYYDDDThhmm/PnD        | R1/1996291T0630+0100/P2D | Repeat once at the 291st day of 1996 at 06:30, UTC + 1 (note the duration is ignored)
+Rn/CCYYDDDThhmm/PnD        | R1/1996291T0630Z/P2D     | Repeat once on the 291st day of 1996 at 06:30 (note the duration is ignored)
 
 #### 4. Recur with a specified duration ending at a particular date-time
 
@@ -335,8 +336,8 @@ duration.
 
 Example Syntax             | Example                  | Meaning
  ------------------------- | ------------------------ | ---------------------------------------------------------------
-R/PTnH/CCYY-MM-DDThhZ      | R/PT1H/2012-01-02T00Z    | Repeat hourly until 2012-01-02T00Z
-R/PnY/CCYY                 | R/P3Y/2000               | Repeat every 3 years until 2000-01-01.
-R/PTnS/+XCCYYDDDThhmm      | R/PT5s/-002500012T1800   | Repeat every 5 seconds until the 12th day in 2501 BC at 18:00 (using 2 expanded year digits).
-Rn/PnYTnM/CCYY-MM-DDThhZ   | R5/P1YT5M/2012-01-02T00Z | Repeat every year and 5 minutes, five times, until 2012-01-02T00Z
-Rn/PnM/CCYY-MM             | R4/P1M/2000-05           | Repeat monthly, four times, until 2000-05-01.
+R/PTnH/CCYY-MM-DDThhZ      | R/PT1H/2012-01-02T00Z    | Repeat hourly, on the hour, ending at 2012-01-02T00Z
+R/PnY/CCYY                 | R/P3Y/2000               | Repeat every 3 years, on January 1st, ending at 2000-01-01
+R/PTnS/+XCCYYDDDThhmm      | R/PT5s/-002500012T1800   | Repeat every 5 seconds, ending on the 12th day in 2501 BC at 18:00 (using 2 expanded year digits)
+Rn/PnYTnM/CCYY-MM-DDThhZ   | R5/P1YT5M/2012-01-02T00Z | Repeat every year and 5 minutes, five times, ending at 2012-01-02T00Z
+Rn/PnM/CCYY-MM             | R4/P1M/2000-05           | Repeat monthly, on the first of the month, four times, ending at 2000-05-01

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -640,7 +640,7 @@ class Duration:
             new._minutes += other._minutes
             new._seconds += other._seconds
             return new
-        if isinstance(other, TimePoint):
+        if isinstance(other, TimePoint) or isinstance(other, TimeRecurrence):
             return other + new
         raise TypeError(
             "Invalid type for addition: " +

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -211,7 +211,6 @@ class TimeRecurrence:
                 self._second_point = self._end_point = self._start_point
                 return
             if self._start_point is None or self._end_point is None:
-                # TODO: add tests for invalid TimeRecurrences
                 raise BadInputError(
                     BadInputError.RECURRENCE, [i[:2] for i in inputs])
             if self._start_point == self._end_point:
@@ -231,7 +230,7 @@ class TimeRecurrence:
                 self._end_point = (
                     self._start_point +
                     self._duration * (self._repetitions - 1))
-        elif self._end_point is None:
+        elif self._end_point is None and self._start_point is not None:
             # Third form.
             self._format_number = 3
             if self._repetitions == 1 or self._duration == Duration(years=0):
@@ -242,7 +241,7 @@ class TimeRecurrence:
                 self._end_point = (
                     self._start_point +
                     self._duration * (self._repetitions - 1))
-        elif self._start_point is None:
+        elif self._start_point is None and self._end_point is not None:
             # Fourth form.
             self._format_number = 4
             if self._repetitions == 1 or self._duration == Duration(years=0):

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -389,12 +389,17 @@ class TimeRecurrence:
                 "Invalid type for addition: '{0}' should be Duration."
                 .format(type(other).__name__)
             )
-        offset_start_point = self._start_point + other
-        # Note: we don't need to worry about the format number as the same
-        # TimeRecurrence can be defined in any of the formats
+        if self._format_number == 1:
+            kwargs = {"start_point": self._start_point + other,
+                      "end_point": self._end_point + other}
+        elif self._format_number == 3:
+            kwargs = {"start_point": self._start_point + other,
+                      "duration": self._duration}
+        elif self._format_number == 4:
+            kwargs = {"end_point": self._end_point + other,
+                      "duration": self._duration}
         return self.__class__(
-            repetitions=self._repetitions,
-            start_point=offset_start_point, duration=self._duration,
+            repetitions=self._repetitions, **kwargs,
             min_point=self._min_point, max_point=self._max_point)
 
     def __sub__(self, other: "Duration") -> "TimeRecurrence":

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -160,12 +160,15 @@ class TimeRecurrence:
 
     Keyword arguments:
 
-    repetitions (int): The number of repetitions in the recurrence. If omitted,
-        the number of repetitions is unbounded.
+    repetitions (int): The number of repetitions in the recurrence. If set
+        to 1, the recurrence simply consists of one date-time, with no
+        duration (i.e., the number of repetitions is inclusive of the first
+        occurrence). If omitted, the number of repetitions is unbounded.
     start_point (TimePoint): Start date-time of the recurrence.
-    duration (Duration): The duration of the recurrence.
-    end_point (TimePoint): End date-time of the recurrence, or if using
-        format 1, the end date-time of the first interval.
+    duration (Duration): The duration of each repetition interval in the
+        recurrence.
+    end_point (TimePoint): End date-time of the recurrence (format 4), or if
+        using format 1, the end date-time of the first interval.
     min_point (TimePoint): If specified, marks the start of a subset of 'valid'
         date-times in the recurrence.
     max_point (TimePoint): If specified, marks the end of a subset of 'valid'

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -364,6 +364,23 @@ class TimeRecurrence:
                 return False
         return True
 
+    def __add__(self, other: "Duration") -> "TimeRecurrence":
+        if not isinstance(other, Duration):
+            raise TypeError(
+                "Invalid type for addition: '{0}' should be Duration."
+                .format(type(other).__name__)
+            )
+        offset_start_point = self._start_point + other
+        # Note: we don't need to worry about the format number as the same
+        # TimeRecurrence can be defined in any of the formats
+        return self.__class__(
+            repetitions=self._repetitions,
+            start_point=offset_start_point, duration=self._duration,
+            min_point=self._min_point, max_point=self._max_point)
+
+    def __sub__(self, other: "Duration") -> "TimeRecurrence":
+        return self + -1 * other
+
     def __str__(self):
         if self._repetitions is None:
             prefix = "R/"

--- a/metomi/isodatetime/parsers.py
+++ b/metomi/isodatetime/parsers.py
@@ -45,7 +45,7 @@ class TimeRecurrenceParser(object):
     """
 
     RECURRENCE_REGEXES = [
-        re.compile(r"^R(?P<reps>\d+)/(?P<start>[^P][^/]*)/(?P<end>[^P].*)$"),
+        re.compile(r"^R(?P<reps>\d+)?/(?P<start>[^P][^/]*)/(?P<end>[^P].*)$"),
         re.compile(r"^R(?P<reps>\d+)?/(?P<start>[^P][^/]*)/(?P<intv>P.+)$"),
         re.compile(r"^R(?P<reps>\d+)?/(?P<intv>P.+)/(?P<end>[^P].*)$")]
 

--- a/metomi/isodatetime/tests/test_00.py
+++ b/metomi/isodatetime/tests/test_00.py
@@ -680,11 +680,18 @@ def get_truncated_property_tests():
 
 
 def get_timerecurrence_expansion_tests():
-    """Return test expansion expressions for data.TimeRecurrence."""
+    """Return test expansion expressions for data.TimeRecurrence.
+
+    If no. of repetitions is unbounded, will test the first three.
+    """
     return [
+        ("R5/2020-01-01T00:00:00Z/2020-01-05T00:00:00Z",
+         ["2020-01-01T00:00:00Z", "2020-01-05T00:00:00Z",
+          "2020-01-09T00:00:00Z", "2020-01-13T00:00:00Z",
+          "2020-01-17T00:00:00Z"]),
         ("R3/1001-W01-1T00:00:00Z/1002-W52-6T00:00:00-05:30",
-         ["1001-W01-1T00:00:00Z", "1001-W53-3T14:45:00Z",
-          "1002-W52-6T05:30:00Z"]),
+         ["1001-W01-1T00:00:00Z", "1002-W52-6T05:30:00Z",
+          "1005-W01-4T11:00:00Z"]),
         ("R3/P700D/1957-W01-1T06,5Z",
          ["1953-W10-1T06,5Z", "1955-W05-1T06,5Z", "1957-W01-1T06,5Z"]),
         ("R3/P5DT2,5S/1001-W11-1T00:30:02,5-02:00",
@@ -717,7 +724,15 @@ def get_timerecurrence_comparison_tests():
         # Format 3 vs 4:
         ("R4/2020-01-01T00Z/P1D", "R4/P1D/2020-01-04T00Z", True),
         ("R/2020-01-01T00Z/P1D", "R/P1D/2020-01-04T00Z", False),
-        # TODO: Format 1 vs others after fixing issue #45
+        # Format 1 vs 3:
+        ("R5/2020-001T00Z/2020-005T00Z", "R5/2020-001T00Z/P4D", True),
+        ("R/2020-02-07T09Z/2020-02-07T10Z", "R/2020-02-07T09Z/PT1H", True),
+        # Format 1 vs 4:
+        ("R5/2020-001T00Z/2020-005T00Z", "R5/P4D/2020-005T00Z", False),
+        ("R5/2020-001T00Z/2020-005T00Z", "R5/P4D/2020-017T00Z", True),
+        ("R/2020-02-07T09Z/2020-02-07T10Z", "R/PT1H/2020-02-07T10Z", False),
+        # Mixed stuff:
+        ("R3/2020-05-01T16Z/PT3H", "R3/2020-W18-5T18:30+02:30/PT180M", True)
     ]
 
 
@@ -840,15 +855,20 @@ def get_timerecurrence_expansion_tests_366():
 def get_timerecurrence_membership_tests():
     """Return test membership expressions for data.TimeRecurrence."""
     return [
+        ("R5/2020-01-01T00:00:00Z/2020-01-05T00:00:00Z",
+         [("2020-01-02T00:00:00Z", False),
+          ("2020-01-17T00:00:00Z", True),
+          ("2020-01-21T00:00:00Z", False)]),
         ("R3/1001-W01-1T00:00:00Z/1002-W52-6T00:00:00-05:30",
          [("1001-W01-1T00:00:00Z", True),
           ("1000-12-29T00:00:00Z", True),
           ("0901-07-08T12:45:00Z", False),
           ("1001-W01-2T00:00:00Z", False),
-          ("1001-W53-3T14:45:00Z", True),
+          ("1001-W53-3T14:45:00Z", False),
           ("1002-W52-6T05:30:00Z", True),
           ("1002-W52-6T03:30:00-02:00", True),
           ("1002-W52-6T07:30:00+02:00", True),
+          ("1005-W01-4T11:00:00Z", True),
           ("10030101T00Z", False)]),
         ("R3/P700D/1957-W01-1T06,5Z",
          [("1953-W10-1T06,5Z", True),
@@ -884,16 +904,13 @@ def get_timerecurrenceparser_tests():
                     continue
                 duration = duration_parser.parse(duration_expr)
                 end_point = start_point + duration
-                if reps is not None:
-                    expr_1 = ("R" + reps_string + "/" + str(start_point) +
-                              "/" + str(end_point))
-                    yield expr_1, {"repetitions": reps,
-                                   "start_point": start_point,
-                                   "end_point": end_point}
+                expr_1 = ("R" + reps_string + "/" + str(start_point) +
+                          "/" + str(end_point))
+                yield expr_1, {"repetitions": reps, "start_point": start_point,
+                               "end_point": end_point}
                 expr_3 = ("R" + reps_string + "/" + str(start_point) +
                           "/" + str(duration))
-                yield expr_3, {"repetitions": reps,
-                               "start_point": start_point,
+                yield expr_3, {"repetitions": reps, "start_point": start_point,
                                "duration": duration}
                 expr_4 = ("R" + reps_string + "/" + str(duration) + "/" +
                           str(end_point))
@@ -1317,9 +1334,10 @@ class TestSuite(unittest.TestCase):
                     expression
                 )
             test_results = []
+            reps = test_recurrence.repetitions or 3
             for i, time_point in enumerate(test_recurrence):
-                if i > 2:
-                    break
+                if i >= reps:
+                    break  # Unbounded repetitions, just test 3 of them
                 test_results.append(str(time_point))
             self.assertEqual(test_results, ctrl_results, expression)
             if test_recurrence.start_point is None:
@@ -1329,17 +1347,17 @@ class TestSuite(unittest.TestCase):
                 forward_method = test_recurrence.get_next
                 backward_method = test_recurrence.get_prev
             test_points = [test_recurrence[0]]
-            test_points.append(forward_method(test_points[-1]))
-            test_points.append(forward_method(test_points[-1]))
+            for i in range(1, reps):
+                test_points.append(forward_method(test_points[-1]))
             test_results = [str(point) for point in test_points]
             self.assertEqual(test_results, ctrl_results, expression)
-            if test_recurrence[2] is not None:
-                test_points = [test_recurrence[2]]
+            # Test that going backwards beyond 1st point results in None:
+            test_points = [test_recurrence[reps - 1]]
+            for i in range(0, reps):
                 test_points.append(backward_method(test_points[-1]))
-                test_points.append(backward_method(test_points[-1]))
-                test_points.append(backward_method(test_points[-1]))
-            self.assertEqual(test_points[3], None, expression)
-            test_points.pop(3)
+            self.assertEqual(test_points[reps], None, expression)
+            # Test backwards method == reverse of forward:
+            test_points.pop(-1)
             test_points.reverse()
             test_results = [str(point) for point in test_points]
             self.assertEqual(test_results, ctrl_results, expression)

--- a/metomi/isodatetime/tests/test_00.py
+++ b/metomi/isodatetime/tests/test_00.py
@@ -22,6 +22,7 @@ import copy
 import datetime
 from itertools import chain
 import unittest
+import pytest
 from unittest.mock import patch, MagicMock, Mock
 
 from metomi.isodatetime import data

--- a/metomi/isodatetime/tests/test_00.py
+++ b/metomi/isodatetime/tests/test_00.py
@@ -1390,6 +1390,37 @@ class TestSuite(unittest.TestCase):
         for var in [7, 'foo', (1, 2), data.Duration(days=1)]:
             self.assertFalse(test_recurrence == var)
 
+    def test_timerecurrence_add(self):
+        """Test adding/subtracting Duration to/from TimeRecurrence"""
+        rep = 4
+        start_pt = data.TimePoint(year=2020, month_of_year=3, day_of_month=13)
+        dur = data.Duration(days=7)
+        end_pt = start_pt + (rep - 1) * dur
+
+        recurrence_fmt1 = data.TimeRecurrence(
+            repetitions=rep, start_point=start_pt, end_point=end_pt)
+        recurrence_fmt3 = data.TimeRecurrence(
+            repetitions=rep, start_point=start_pt, duration=dur)
+        recurrence_fmt4 = data.TimeRecurrence(
+            repetitions=rep, duration=dur, end_point=end_pt)
+        assert recurrence_fmt3 == recurrence_fmt4
+
+        offset = data.Duration(hours=9)
+        new_start_pt = start_pt + offset
+        expected = data.TimeRecurrence(
+            repetitions=rep, start_point=new_start_pt, duration=dur)
+        assert recurrence_fmt3 + offset == expected
+        assert recurrence_fmt4 + offset == expected
+
+        new_start_pt = start_pt - offset
+        expected = data.TimeRecurrence(
+            repetitions=rep, start_point=new_start_pt, duration=dur)
+        assert recurrence_fmt3 - offset == expected
+        assert recurrence_fmt4 - offset == expected
+
+        with pytest.raises(TypeError):
+            recurrence_fmt3 + data.TimePoint(year=2049, month_of_year=2)
+
     # data provider for the test test_get_local_time_zone_no_dst
     # the format for the parameters is
     # [tz_seconds, expected_hours, expected_minutes]]

--- a/metomi/isodatetime/tests/test_00.py
+++ b/metomi/isodatetime/tests/test_00.py
@@ -1413,28 +1413,32 @@ class TestSuite(unittest.TestCase):
         rep = 4
         start_pt = data.TimePoint(year=2020, month_of_year=3, day_of_month=13)
         dur = data.Duration(days=7)
-        end_pt = start_pt + (rep - 1) * dur
 
         recurrence_fmt1 = data.TimeRecurrence(
-            repetitions=rep, start_point=start_pt, end_point=end_pt)
+            repetitions=rep, start_point=start_pt,
+            end_point=data.TimePoint(year=2020, month_of_year=3,
+                                     day_of_month=20))
         recurrence_fmt3 = data.TimeRecurrence(
             repetitions=rep, start_point=start_pt, duration=dur)
         recurrence_fmt4 = data.TimeRecurrence(
-            repetitions=rep, duration=dur, end_point=end_pt)
+            repetitions=rep, duration=dur,
+            end_point=data.TimePoint(year=2020, month_of_year=4,
+                                     day_of_month=3))
         assert recurrence_fmt3 == recurrence_fmt4
 
-        offset = data.Duration(hours=9)
+        offset = data.Duration(hours=9, minutes=59)
         new_start_pt = start_pt + offset
         expected = data.TimeRecurrence(
             repetitions=rep, start_point=new_start_pt, duration=dur)
-        assert recurrence_fmt3 + offset == expected
-        assert recurrence_fmt4 + offset == expected
+        for recurrence in (recurrence_fmt1, recurrence_fmt3, recurrence_fmt4):
+            assert recurrence + offset == expected
+            assert offset + recurrence == expected
 
         new_start_pt = start_pt - offset
         expected = data.TimeRecurrence(
             repetitions=rep, start_point=new_start_pt, duration=dur)
-        assert recurrence_fmt3 - offset == expected
-        assert recurrence_fmt4 - offset == expected
+        for recurrence in (recurrence_fmt1, recurrence_fmt3, recurrence_fmt4):
+            assert recurrence - offset == expected
 
         with pytest.raises(TypeError):
             recurrence_fmt3 + data.TimePoint(year=2049, month_of_year=2)

--- a/metomi/isodatetime/tests/test_main.py
+++ b/metomi/isodatetime/tests/test_main.py
@@ -247,13 +247,13 @@ class TestMain(unittest.TestCase):
         """Test calling usage 4, sample bad arguments."""
         argv = sys.argv
         mock_print.reset_mock()
-        sys.argv = ['', 'R/2020/2025']
+        sys.argv = ['', 'R-1/2020/2025']
         try:
             with self.assertRaises(SystemExit) as ctxmgr:
                 isodatetime_main.main()
             mock_print.assert_not_called()
             self.assertEqual(
-                'Invalid ISO 8601 recurrence representation: R/2020/2025',
+                'Invalid ISO 8601 recurrence representation: R-1/2020/2025',
                 str(ctxmgr.exception))
         finally:
             sys.argv = argv


### PR DESCRIPTION
Follow up to #165

- Implements an `__add__` & `__sub__` methods in TimeRecurrence, allowing Durations to be added to TimeRecurrences. This takes the recurrence series and offsets it by the given duration.
- Fixes a longstanding bug #45 where the implementation of TimeRecurrence format no. 1 was incorrect. This format seems rarely used in Cylc so hopefully we can get away with this breaking change.

  > The first recurrence format should not define repetitions in between the given start and end date - it actually should just extract the interval between the start and end dates and repeat that interval, starting at the start date

___

- [x] Includes tests
- [x] Changelog updated