### PR TITLE
Replace pycodestyle with flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,11 @@ install:
   # PyTest to use environment variables in its configuration (e.g. TZ=UTC).
   - pip install coverage pytest-cov pytest-env pytest-runner
   # Code style dependencies
-  - pip install pycodestyle
+  - pip install flake8
   - pip install -e .
 
 before_script:
-  - pycodestyle -v metomi/isodatetime
+  - flake8 -v metomi/isodatetime
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,7 @@ install:
   # PyTest to use environment variables in its configuration (e.g. TZ=UTC).
   - pip install coverage pytest-cov pytest-env pytest-runner
   # Code style dependencies
-  - pip install flake8
-  - pip install -e .
+  - pip install -e .[all]
 
 before_script:
   - flake8 -v metomi/isodatetime

--- a/metomi/isodatetime/tests/test_00.py
+++ b/metomi/isodatetime/tests/test_00.py
@@ -21,7 +21,6 @@
 import copy
 import datetime
 from itertools import chain
-import pytest
 import unittest
 from unittest.mock import patch, MagicMock, Mock
 

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,12 @@ if {'pytest', 'test', 'ptr'}.intersection(sys.argv):
 else:
     setup_requires = []
 
+tests_require = [
+    'coverage', 'pytest>=5', 'pytest-cov', 'pytest-env', 'flake8'
+]
+
+install_requires = []
+
 setup(
     name="metomi-isodatetime",
     version='1!' + __version__,
@@ -95,8 +101,11 @@ setup(
     long_description_content_type="text/markdown",
     platforms='any',
     setup_requires=setup_requires,
-    tests_require=['coverage', 'pytest>=5', 'pytest-cov', 'pytest-env'],
-    install_requires=[],
+    tests_require=tests_require,
+    install_requires=install_requires,
+    extras_require={
+        'all': setup_requires + tests_require + install_requires
+    },
     python_requires='>=3.5',
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Other projects related to this one have been moving to using flake8.
This change proposed for the sake of consistency.