### PR TITLE
GH Actions: Fix order of actions

### DIFF
--- a/.github/workflows/auto_publish_release.yml
+++ b/.github/workflows/auto_publish_release.yml
@@ -21,9 +21,6 @@ jobs:
     timeout-minutes: 5
     steps:
 
-    - name: Get the version number
-      uses: cylc/release-actions/stage-2/get-version-from-pr@v1
-
     - name: Checkout repo
       uses: actions/checkout@v2
       with:
@@ -34,11 +31,14 @@ jobs:
       with:
         python-version: '3.x'
 
+    - name: Get the version number
+      uses: cylc/release-actions/stage-2/get-version-from-pr@v1
+
     - name: Build
       uses: cylc/release-actions/build-python-package@v1
 
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.3.1
+      uses: pypa/gh-action-pypi-publish@v1.4.1
       with:
         user: __token__ # uses the API token feature of PyPI - least permissions possible
         password: ${{ secrets.PYPI_TOKEN }}
@@ -52,6 +52,7 @@ jobs:
         commitish: ${{ env.MERGE_SHA }}
         tag_name: ${{ env.VERSION }}
         release_name: isodatetime ${{ env.VERSION }}
+        prerelease: ${{ env.PRERELEASE }}
         body: See [${{ env.CHANGELOG_FILE }}](https://github.com/${{ github.repository }}/blob/master/${{ env.CHANGELOG_FILE }}) for detail.
         # TODO: Get topmost changelog section somehow and use that as the body?
 

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -47,8 +47,6 @@ jobs:
 
     - name: Test the build
       uses: cylc/release-actions/build-python-package@v1
-      with:
-        dry-run: true
 
     - name: Create pull request
       uses: cylc/release-actions/stage-1/create-release-pr@v1

--- a/.github/workflows/update_copyright.yml
+++ b/.github/workflows/update_copyright.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   update-copyright:
+    if: github.repository_owner == 'metomi'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/update_copyright.yml
+++ b/.github/workflows/update_copyright.yml
@@ -3,6 +3,7 @@ name: Update copyright year
 on:
   schedule:
     - cron: '0 12 1 1 *' # Every Jan 1st @ 12:00 UTC
+  workflow_dispatch:
 
 jobs:
   update-copyright:
@@ -14,16 +15,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Configure git
-      run: |
-        git config --global user.name "github-actions[bot]"
-        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      uses: cylc/release-actions/configure-git@v1
 
-        year=$(date '+%Y' --utc)
-        branch_name="copyright-${year}"
-        git checkout -b "$branch_name"
-
-        echo "YEAR=$year" >> $GITHUB_ENV
-        echo "BRANCH_NAME=$branch_name" >> $GITHUB_ENV
+    - name: Checkout PR branch
+      uses: cylc/release-actions/checkout-copyright-branch@v1
 
     - name: Update copyright year
       run: |
@@ -33,20 +28,15 @@ jobs:
     - name: Commit & push
       run : |
         git commit -a -m "Update copyright year" -m "Workflow: ${{ github.workflow }}, run: ${{ github.run_number }}"
-        git push origin "$BRANCH_NAME"
+        git push
 
     - name: Create pull request
+      uses: cylc/release-actions/create-pr@v1
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        curl -X POST \
-          https://api.github.com/repos/${{ github.repository }}/pulls \
-          -H "authorization: Bearer ${GH_TOKEN}" \
-          -H 'content-type: application/json' \
-          --data '{
-            "title": "Auto PR: update copyright year",
-            "head": "${{ env.BRANCH_NAME }}",
-            "base": "master",
-            "body": "Happy new year!"
-          }'
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        head: ${{ env.BRANCH_NAME }}
+        title: 'Auto PR: update copyright year'
+        body: 'Happy new year!'
+
 


### PR DESCRIPTION
https://github.com/cylc/release-actions/pull/6 inadvertently broke the workflow

Also includes some tidying up and a fix for the update_copyright workflow running on forks

See https://github.com/MetRonnie/isodatetime/pull/1 for a test run (succeded - the failure is merely due to the missing PyPI token on my fork, as expected)