### PR TITLE
Fix west-of-UTC time zone bug

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10-dev']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10-dev']
         coverage: [false]
         include:
           # Modify existing configurations:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           TZ: ${{ matrix.tz }}
         run: |
-          PYTEST_ARGS=('-n' '2')
+          PYTEST_ARGS=(-n 2 -m 'slow or not slow')
           if ${{ matrix.coverage }}; then
             PYTEST_ARGS+=('--cov=metomi/isodatetime')
           fi

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ ones in. -->
 
 ## isodatetime 2.1.0 (<span actions:bind='release-date'>Upcoming, 2020</span>)
 
-This is the 15th release of isodatetime. Requires Python 3.5+.
+This is the 15th release of isodatetime. **Requires Python 3.6+**.
 
 ### Noteworthy Changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,10 @@ Replaced `TimePoint.get("attribute_name")` method with individual attributes
 `TimePoint.attribute_name`. Fixed a bug in rounding decimal properties of
 TimePoints.
 
+[#193](https://github.com/metomi/isodatetime/pull/193):
+Fixed a bug where the `timezone` functions would return incorrect results
+for certain non-standard/unusual system time zones.
+
 --------------------------------------------------------------------------------
 
 ## isodatetime 2.0.2 (Released 2020-07-01)

--- a/metomi/isodatetime/tests/conftest.py
+++ b/metomi/isodatetime/tests/conftest.py
@@ -1,0 +1,41 @@
+# Copyright (C) British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+import time
+from unittest.mock import Mock
+
+
+@pytest.fixture
+def mock_local_time_zone(monkeypatch: pytest.MonkeyPatch):
+    """A pytest fixture that simulates a given local system time zone.
+
+    Args:
+        seconds: The number of seconds UTC offset for the base time zone.
+        dst_seconds: The number of seconds UTC offset for the daylight savings
+            time zone.
+
+    Note: these args are positive for time zones East of the prime meridian
+    and negative for West.
+    """
+    def _mock_local_time_zone(seconds: int, dst_seconds: int = 0) -> None:
+        is_dst = 1 if dst_seconds else 0
+        mock_time = Mock(spec=time)
+        mock_time.timezone = -seconds
+        mock_time.altzone = -dst_seconds
+        mock_time.daylight = is_dst
+        mock_time.localtime.return_value = Mock(tm_isdst=is_dst)
+        monkeypatch.setattr('metomi.isodatetime.timezone.time', mock_time)
+    return _mock_local_time_zone

--- a/metomi/isodatetime/tests/test_timezone.py
+++ b/metomi/isodatetime/tests/test_timezone.py
@@ -1,0 +1,155 @@
+# Copyright (C) British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This tests the timezone module."""
+
+from typing import Callable, Tuple
+import pytest
+
+from metomi.isodatetime import timezone
+
+
+@pytest.mark.parametrize('dst', [True, False])
+@pytest.mark.parametrize(
+    'tz_seconds, expected_no_dst, tz_dst_seconds, expected_with_dst',
+    [
+        pytest.param(
+            45900, (12, 45),
+            49500, (13, 45),
+            id="pacific/chatham, +12:45 and +13:45"
+        ),
+        pytest.param(
+            20700, (5, 45),
+            20700, (5, 45),
+            id="asia/kathmandu, +05:45"
+        ),
+        pytest.param(
+            3600, (1, 0),
+            7200, (2, 0),
+            id="europe/oslo, +01:00 and +02:00"
+        ),
+        pytest.param(
+            0, (0, 0),
+            0, (0, 0),
+            id="UTC"
+        ),
+        pytest.param(
+            0, (0, 0),
+            3600, (1, 0),
+            id="europe/london, +00:00 and +01:00"
+        ),
+        pytest.param(
+            -12600, (-3, 30),
+            -9000, (-2, 30),
+            id="america/st_johns, -03:30 and -02:30"
+        ),
+        pytest.param(
+            -5*3600, (-5, 0),
+            -4*3600, (-4, 0),
+            id="america/new_york, -05:00 and -04:00,"
+        ),
+        pytest.param(
+            -8100, (-2, 15),
+            -8100, (-2, 15),
+            id="hypothetical -02:15"
+        ),
+        pytest.param(
+            -1800, (0, -30),
+            -2400, (0, -40),
+            id="hypothetical -0:30 and -0:40"
+        ),
+    ]
+)
+def test_get_local_time_zone(
+    dst: bool,
+    tz_seconds: int,
+    expected_no_dst: Tuple[int, int],
+    tz_dst_seconds: int,
+    expected_with_dst: Tuple[int, int],
+    mock_local_time_zone: Callable
+):
+    """Test that the hour/minute returned is correct.
+
+    Params:
+        dst: Whether to simulate daylight savings time.
+        tz_seconds: Time zone UTC offset when not in DST.
+        expected_no_dst: Expected return value when in DST.
+        tz_dst_seconds: Time zone UTC offset when in DST.
+        expected_with_dst: Expected return value when not in DST.
+    """
+    mock_local_time_zone(
+        tz_seconds,
+        tz_dst_seconds if dst else 0
+    )
+    expected = expected_with_dst if dst else expected_no_dst
+    assert timezone.get_local_time_zone() == expected
+
+
+@pytest.mark.parametrize(
+    'tz_seconds, expected_formats',
+    [
+        pytest.param(
+            0, ('Z', 'Z', 'Z'),  # flags are never used for UTC
+            id="UTC"
+        ),
+        # Positive values, some with minutes != 0
+        pytest.param(
+            28800, ('+0800', '+08:00', '+08'),
+            id="asia/macao"
+        ),
+        pytest.param(
+            45900, ('+1245', '+12:45', '+1245'),
+            id="pacific/chatham"
+        ),
+        # Negative values, some with minutes != 0
+        pytest.param(
+            -3*3600, ('-0300', '-03:00', '-03'),
+            id="america/buenos_aires"
+        ),
+        pytest.param(
+            -12600, ('-0330', '-03:30', '-0330'),
+            id="america/st_johns"
+        ),
+        pytest.param(
+            -8100, ('-0215', '-02:15', '-0215'),
+            id="hypothetical -02:15"
+        ),
+        pytest.param(
+            -1800, ('-0030', '-00:30', '-0030'),
+            id="hypothetical -00:30"
+        ),
+    ]
+)
+def test_get_local_time_zone_format(
+    tz_seconds: int,
+    expected_formats: Tuple[int, int, int],
+    mock_local_time_zone: Callable
+):
+    """Test that the UTC offset string format is correct.
+
+    Params:
+        tz_seconds: The time zone's UTC offset.
+        expected_formats: The expected return values for normal, extended
+            and reduced formats, respectively.
+    """
+    # DST is not really important for this test
+    mock_local_time_zone(tz_seconds)
+    for i, tz_format_mode in enumerate([
+        timezone.TimeZoneFormatMode.normal,
+        timezone.TimeZoneFormatMode.extended,
+        timezone.TimeZoneFormatMode.reduced
+    ]):
+        expected = expected_formats[i]
+        assert timezone.get_local_time_zone_format(tz_format_mode) == expected

--- a/metomi/isodatetime/tests/test_timezone.py
+++ b/metomi/isodatetime/tests/test_timezone.py
@@ -51,8 +51,8 @@ from metomi.isodatetime import timezone
             id="europe/london, +00:00 and +01:00"
         ),
         pytest.param(
-            -12600, (-3, 30),
-            -9000, (-2, 30),
+            -12600, (-3, -30),
+            -9000, (-2, -30),
             id="america/st_johns, -03:30 and -02:30"
         ),
         pytest.param(
@@ -61,8 +61,8 @@ from metomi.isodatetime import timezone
             id="america/new_york, -05:00 and -04:00,"
         ),
         pytest.param(
-            -8100, (-2, 15),
-            -8100, (-2, 15),
+            -8100, (-2, -15),
+            -8100, (-2, -15),
             id="hypothetical -02:15"
         ),
         pytest.param(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-# ----------------------------------------------------------------------------
 # Copyright (C) British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
@@ -14,10 +12,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# ----------------------------------------------------------------------------
 
 [pytest]
 addopts = -v -s -ra --color=auto --doctest-glob='*.md'
-# Some tests fail when running in a different time zone (e.g. Pacific/Auckland)
 markers = slow
 testpaths = metomi/isodatetime/tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,6 +14,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 [pytest]
-addopts = -v -s -ra --color=auto --doctest-glob='*.md'
-markers = slow
-testpaths = metomi/isodatetime/tests
+addopts =
+    -v
+    -s
+    -ra
+    --color=auto
+    --doctest-glob='*.md'
+    -m 'not slow'
+markers =
+    slow: mark a test as slow - it will be skipped by default (use '-m "slow or not slow"' to run all tests)
+testpaths =
+    metomi/isodatetime/tests

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
     install_requires=install_requires,
     tests_require=tests_require,
     extras_require=extras_require,
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Other Environment",
@@ -100,10 +100,10 @@ setup(
         ("License :: OSI Approved" +
          " :: GNU Lesser General Public License v3 (LGPLv3)"),
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Utilities"


### PR DESCRIPTION
Closes #192

Fixes a bug where `metomi.isodatetime.timezone` would return incorrect results for certain non-standard/unusual system time zones. Also, `get_local_time_zone()` now always returns negative minutes for time zones behind UTC. 

This PR also drops support for Python 3.5, and makes `-m 'not slow'` the default for pytest.