### PR TITLE
Tidy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
             coverage: false
     name: ${{ matrix.os }} py-${{ matrix.python-version }} ${{ matrix.tz }} ${{ matrix.coverage && '(coverage)' || '' }}
     env:
-      PYTEST_ADDOPTS: -n 5 -m 'slow or not slow'
+      PYTEST_ADDOPTS: -n 5 -m 'slow or not slow' --color=yes
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,13 @@ creating a new release entry be sure to copy & paste the span tag with the
 `actions:bind` attribute, which is used by a regex to find the text to be
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
---------------------------------------------------------------------------------
+## isodatetime 3.2.0 (<span actions:bind='release-date'>Upcoming</span>)
+
+### Breaking changes
+
+[#203](https://github.com/metomi/isodatetime/pull/203):
+`TimePoint.seconds_since_unix_epoch` is now an `int` instead of `str`.
+
 
 ## isodatetime 3.1.0 (<span actions:bind='release-date'>Released 2023-10-05</span>)
 
@@ -19,7 +25,6 @@ Requires Python 3.7+
 [#231](https://github.com/metomi/isodatetime/pull/231):
 Fixed mistakes in the CLI help text.
 
---------------------------------------------------------------------------------
 
 ## isodatetime 3.0.0 (<span actions:bind='release-date'>Released 2022-03-31</span>)
 
@@ -44,7 +49,6 @@ TimePoints.
 Fixed a bug where the `timezone` functions would return incorrect results
 for certain non-standard/unusual system time zones.
 
---------------------------------------------------------------------------------
 
 ## isodatetime 2.0.2 (Released 2020-07-01)
 
@@ -62,7 +66,6 @@ CLI can now read in from piped stdin.
 TimePoints can no longer be created with out-of-bounds values, e.g.
 `2020-00-00`, `2020-13-32T25:60`, `--02-30` are not valid.
 
---------------------------------------------------------------------------------
 
 ## isodatetime 2.0.1 (Released 2019-07-23)
 
@@ -86,7 +89,6 @@ Support the CF compatible calendar mode strings `360_day`, `365_day` & `366_day`
 [#132](https://github.com/metomi/isodatetime/pull/132):
 Change namespace of `isodatetime` to `metomi.isodatetime`
 
---------------------------------------------------------------------------------
 
 ## isodatetime 2.0.0 (Released 2019-01-22)
 
@@ -119,7 +121,6 @@ Fixed time point dumper time zone inconsistency.
 [#118](https://github.com/metomi/isodatetime/pull/118):
 Fixed time point dumper date type inconsistency.
 
---------------------------------------------------------------------------------
 
 ## isodatetime 2018.11.0 (Released 2018-11-05)
 
@@ -143,7 +144,6 @@ Fix for timezone offsets where minutes are not 0.
 [#87](https://github.com/metomi/isodatetime/pull/87):
 Add `setup.py`.
 
---------------------------------------------------------------------------------
 
 ## isodatetime 2018.09.0 (Released 2018-09-11)
 
@@ -155,7 +155,6 @@ This is the 10th release of isodatetime.
 New TimePoint method to find the next smallest property that is missing from a
 truncated representation.
 
---------------------------------------------------------------------------------
 
 ## isodatetime 2018.02.0 (Released 2018-02-06)
 
@@ -166,7 +165,6 @@ This is the 9th release of isodatetime.
 [#82](https://github.com/metomi/isodatetime/pull/82):
 Fix subtracting a later timepoint from an earlier one.
 
---------------------------------------------------------------------------------
 
 ## isodatetime 2017.08.0 (Released 2017-08-09)
 
@@ -180,13 +178,11 @@ Fix error string for bad conversion for strftime/strptime.
 [#74](https://github.com/metomi/isodatetime/pull/74):
 Slotted the data classes to improve memory footprint.
 
---------------------------------------------------------------------------------
 
 ## isodatetime 2017.02.1 (Released 2017-02-21)
 
 This is the 7th release of isodatetime. Admin only release.
 
---------------------------------------------------------------------------------
 
 ## isodatetime 2017.02.0 (Released 2017-02-20)
 
@@ -197,7 +193,6 @@ This is the 6th release of isodatetime.
 [#73](https://github.com/metomi/isodatetime/pull/73):
 Fix adding duration not in weeks and duration in weeks.
 
---------------------------------------------------------------------------------
 
 ## isodatetime 2014.10.0 (Released 2014-10-01)
 
@@ -216,7 +211,6 @@ Fix `date1 - date2` where `date2` is greater than `date1` and `date1` and
 [#60](https://github.com/metomi/isodatetime/pull/60):
 Stricter dumper year bounds checking.
 
---------------------------------------------------------------------------------
 
 ## isodatetime 2014.08.0 (Released 2014-08-11)
 
@@ -235,7 +229,6 @@ digits.
 Speeds up calculations involving counting the days over a number of consecutive
 years.
 
---------------------------------------------------------------------------------
 
 ## isodatetime 2014.07.0 (Released 2014-07-29)
 
@@ -253,7 +246,6 @@ More flexible API for calendar mode.
 [#48](https://github.com/metomi/isodatetime/pull/48):
 `TimeInterval` class: add `get_seconds` method and input prettifying.
 
---------------------------------------------------------------------------------
 
 ## isodatetime 2014.06.0 (Released 2014-06-19)
 
@@ -279,7 +271,6 @@ Implement subset of strftime/strptime POSIX standard.
 [#28](https://github.com/metomi/isodatetime/pull/28):
 Fix get next point for single-repetition recurrences.
 
---------------------------------------------------------------------------------
 
 ## isodatetime 2014-03 (Released 2014-03-13)
 

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -552,19 +552,17 @@ class Duration:
     @property
     def seconds(self): return self._seconds
 
-    def _copy(self):
+    def _copy(self) -> 'Duration':
         """Return an (unlinked) copy of this instance."""
         new = self.__class__(_is_empty_instance=True)
         for attr in self.__slots__:
             setattr(new, attr, getattr(self, attr))
         return new
 
-    def is_exact(self):
+    def is_exact(self) -> bool:
         """Return True if the instance is defined in non-nominal/exact units
         (weeks, days, hours, minutes or seconds) only."""
-        if self._years or self._months:
-            return False
-        return True
+        return not (self._years or self._months)
 
     def get_days_and_seconds(self):
         """Return a roughly-converted duration in days and seconds.

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -1300,12 +1300,12 @@ class TimePoint:
         return "+"
 
     @property
-    def seconds_since_unix_epoch(self):
+    def seconds_since_unix_epoch(self) -> int:
         reference_timepoint = TimePoint(
             **CALENDAR.UNIX_EPOCH_DATE_TIME_REFERENCE_PROPERTIES)
         days, seconds = (self - reference_timepoint).get_days_and_seconds()
         # N.B. This needs altering if we implement leap seconds.
-        return str(int(CALENDAR.SECONDS_IN_DAY * days + seconds))
+        return int(CALENDAR.SECONDS_IN_DAY * days + seconds)
 
     def get(self, property_name):
         """Obsolete method for returning calculated value for property name."""

--- a/metomi/isodatetime/tests/test_01.py
+++ b/metomi/isodatetime/tests/test_01.py
@@ -612,6 +612,13 @@ class TestDataModel(unittest.TestCase):
             self.assertEqual(test_subtract, end_point,
                              "%s - %s" % (start_point, test_duration))
 
+    def test_duration_is_exact(self):
+        """Test Duration.is_exact()."""
+        duration = data.Duration(weeks=1, days=1)
+        assert duration.is_exact()
+        for duration in (data.Duration(months=1), data.Duration(years=1)):
+            assert not duration.is_exact()
+
     def test_timepoint_comparison(self):
         """Test the TimePoint rich comparison methods and hashing."""
         run_comparison_tests(data.TimePoint, get_timepoint_comparison_tests())


### PR DESCRIPTION
Accumulation of various acts of tidying over the months.

One relatively noteworthy behaviour change: `TimePoint.seconds_since_unix_epoch` is now an `int` instead of `str`.