### PR TITLE
cli: fix issue with negative durations

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -58,7 +58,7 @@ coverage:
 
 # files to ignore
 ignore:
-  - "isodatetime/tests*"
+  - "metomi/isodatetime/tests*"
 
 # turn off comments to pull requests
 comment: off

--- a/metomi/isodatetime/main.py
+++ b/metomi/isodatetime/main.py
@@ -174,7 +174,7 @@ from . import __version__
 from .datetimeoper import DateTimeOperator
 
 
-def parse_args():
+def parse_args(sys_args=None):
     arg_parser = ArgumentParser(
         prog='isodatetime',
         formatter_class=RawDescriptionHelpFormatter,
@@ -282,10 +282,13 @@ def parse_args():
         ],
     ]:
         arg_parser.add_argument(*o_args, **o_kwargs)
+
+    if sys_args is None:
+        sys_args = sys.argv[1:]
     if hasattr(arg_parser, 'parse_intermixed_args'):
-        args = arg_parser.parse_intermixed_args()
+        args = arg_parser.parse_intermixed_args(sys_args)
     else:
-        args = arg_parser.parse_args()
+        args = arg_parser.parse_args(sys_args)
 
     if args.offsets1:
         args.offsets1 = [item.replace("\\", "") for item in args.offsets1]
@@ -296,9 +299,9 @@ def parse_args():
     return args
 
 
-def main():
+def main(sys_args=None):
     """Implement "isodatetime" command."""
-    args = parse_args()
+    args = parse_args(sys_args)
 
     if args.version_mode:
         print(__version__)

--- a/metomi/isodatetime/main.py
+++ b/metomi/isodatetime/main.py
@@ -285,6 +285,10 @@ def parse_args(sys_args=None):
 
     if sys_args is None:
         sys_args = sys.argv[1:]
+    sys_args = [
+        rf'\{arg}' if arg.startswith('-P') else arg
+        for arg in sys_args
+    ]
     if hasattr(arg_parser, 'parse_intermixed_args'):
         args = arg_parser.parse_intermixed_args(sys_args)
     else:

--- a/metomi/isodatetime/tests/test_main.py
+++ b/metomi/isodatetime/tests/test_main.py
@@ -20,8 +20,6 @@
 
 import os
 from subprocess import PIPE, Popen  # nosec
-import sys
-import unittest
 from unittest.mock import patch
 
 import pytest
@@ -30,233 +28,193 @@ import metomi.isodatetime
 import metomi.isodatetime.main as isodatetime_main
 
 
-class TestMain(unittest.TestCase):
-    """Test isodatetime.main.main."""
+@patch('builtins.print')
+def test_1_version(mock_print):
+    """Test print version."""
+    for args in [['--version'], ['-V']]:
+        isodatetime_main.main(args)
+        mock_print.assert_called_with(
+            metomi.isodatetime.__version__
+        )
 
-    @patch('builtins.print')
-    def test_1_version(self, mock_print):
-        """Test print version."""
-        argv = sys.argv
-        for args in [['--version'], ['-V']]:
-            sys.argv = [''] + args
-            try:
-                isodatetime_main.main()
-                mock_print.assert_called_with(
-                    metomi.isodatetime.__version__
-                )
-            finally:
-                sys.argv = argv
 
-    @patch('builtins.print')
-    def test_1_null(self, mock_print):
-        """Test calling usage 1, no or now argument."""
-        argv = sys.argv
-        with patch.object(
-            isodatetime_main.DateTimeOperator,
-            'process_time_point_str',
-            return_value='20190101T1234Z'
-        ):
-            for args in [[''], ['now']]:
-                sys.argv = args
-                try:
-                    isodatetime_main.main()
-                    mock_print.assert_called_with('20190101T1234Z')
-                finally:
-                    sys.argv = argv
+@patch('builtins.print')
+def test_1_null(mock_print):
+    """Test calling usage 1, no or now argument."""
+    with patch.object(
+        isodatetime_main.DateTimeOperator,
+        'process_time_point_str',
+        return_value='20190101T1234Z'
+    ):
+        for arg in ['', 'now']:
+            isodatetime_main.main([arg])
+            mock_print.assert_called_with('20190101T1234Z')
 
-    @patch('builtins.print')
-    def test_1_good(self, mock_print):
-        """Test calling usage 1, sample good arguments."""
-        env_ref = isodatetime_main.DateTimeOperator.ENV_REF
-        ref = os.environ.get(env_ref)
-        argv = sys.argv
-        for args, out in [
-            (['20200101T00Z'], '20200101T00Z'),
-            (['ref'], '20201225T0000Z'),
-            # UTC mode
-            (['-u', '20200101T00+0100'], '20191231T23+0000'),
-            (['--utc', '20200101T00+0100'], '20191231T23+0000'),
-            # With offsets
-            (['-s', 'P1D', '20191231T00Z'], '20200101T00Z'),
-            (['-s', 'P1D', '--offset=PT1H', '20191231T00Z'], '20200101T01Z'),
-            # Negative duration
-            (['-s', 'P1D', '--offset=-PT1H', '20191231T00Z'], '20191231T23Z'),
-            (['-s', 'P1D', '--offset', '\\-PT1H', '20191231T00Z'],
-             '20191231T23Z'),
-            # Print format
-            (['-f', 'CCYY', '20191231T00Z'], '2019'),
-            (['--format', 'CCYY', '20191231T00Z'], '2019'),
-            (['--print-format', 'CCYY', '20191231T00Z'], '2019'),
-            (['20200101T00-1130', '-f', 'CCYYMMDDThhmm+0000'],
-             '20200101T1130+0000'),
-            # Parse format
-            (['--parse-format=%d/%m/%Y', '-f', 'CCYY-MM-DD', '31/12/2019'],
-             '2019-12-31'),
-            (['-p', '%d/%m/%Y', '-f', 'CCYY-MM-DD', '31/12/2019'],
-             '2019-12-31'),
-        ]:
-            sys.argv = [''] + args
-            os.environ[env_ref] = '20201225T0000Z'
-            try:
-                isodatetime_main.main()
-                mock_print.assert_called_with(out)
-            finally:
-                sys.argv = argv
-                if ref is not None:
-                    os.environ[env_ref] = ref
-                else:
-                    del os.environ[env_ref]
 
-    @patch('builtins.print')
-    def test_1_bad(self, mock_print):
-        """Test calling usage 1, sample bad arguments."""
-        argv = sys.argv
-        for args, out in [
-            # Bad time point string
-            (['201abc'], 'Invalid ISO 8601 date representation: 201abc'),
-            # Bad offset string
-            (['-s', 'add-a-year', '2019'], 'add-a-year: bad offset value'),
-        ]:
-            mock_print.reset_mock()
-            sys.argv = [''] + args
-            try:
-                with self.assertRaises(SystemExit) as ctxmgr:
-                    isodatetime_main.main()
-                mock_print.assert_not_called()
-                self.assertEqual(out, str(ctxmgr.exception))
-            finally:
-                sys.argv = argv
-
-    @patch('builtins.print')
-    def test_2_good(self, mock_print):
-        """Test calling usage 2, sample good arguments."""
-        env_ref = isodatetime_main.DateTimeOperator.ENV_REF
-        ref = os.environ.get(env_ref)
-        argv = sys.argv
-        for args, out in [
-            # Same
-            (['ref', 'ref'], 'P0Y'),
-            (['20380119', '20380119'], 'P0Y'),
-            # Positive duration
-            (['20181225', '20191225'], 'P365D'),
-            (['-1', 'PT12H', '-2', 'PT12H', '20181225', '20191225'], 'P365D'),
-            # Negative duration
-            (['20191225', '20181225'], '-P365D'),
-            (['--offset1=-PT6H', '--offset2=-PT6H', '20191225', '20181225'],
-             '-P365D'),
-            (['--offset1', '\\-PT6H', '--offset2', '\\-PT6H', '20191225',
-             '20181225'], '-P365D'),
-        ]:
-            sys.argv = [''] + args
-            os.environ[env_ref] = '20201225T0000Z'
-            try:
-                isodatetime_main.main()
-                mock_print.assert_called_with(out)
-            finally:
-                sys.argv = argv
-                if ref is not None:
-                    os.environ[env_ref] = ref
-                else:
-                    del os.environ[env_ref]
-
-    @patch('builtins.print')
-    def test_2_bad(self, mock_print):
-        """Test calling usage 2, sample bad arguments."""
-        argv = sys.argv
-        for args, out in [
-            # Bad time point string
-            (['201abc', '2020'],
-             'Invalid ISO 8601 date representation: 201abc'),
-            # Bad offset string
-            (['-1', 'add-a-year', '2018', '2019'],
-             'add-a-year: bad offset value'),
-        ]:
-            mock_print.reset_mock()
-            sys.argv = [''] + args
-            try:
-                with self.assertRaises(SystemExit) as ctxmgr:
-                    isodatetime_main.main()
-                mock_print.assert_not_called()
-                self.assertEqual(out, str(ctxmgr.exception))
-            finally:
-                sys.argv = argv
-
-    @patch('builtins.print')
-    def test_3_good(self, mock_print):
-        """Test calling usage 3, sample good arguments."""
-        argv = sys.argv
-        for args, out in [
-            # Same
-            (['--as-total=s', 'PT1H30M'], 5400),
-            (['--as-total=s', 'P1D'], 86400),
-            (['--as-total=h', 'P1D'], 24),
-        ]:
-            sys.argv = [''] + args
-            try:
-                isodatetime_main.main()
-                mock_print.assert_called_with(out)
-            finally:
-                sys.argv = argv
-
-    @patch('builtins.print')
-    def test_3_bad(self, mock_print):
-        """Test calling usage 3, sample bad arguments."""
-        argv = sys.argv
-        mock_print.reset_mock()
-        sys.argv = ['', '--as-total=s', 'PS4']
+@patch('builtins.print')
+def test_1_good(mock_print):
+    """Test calling usage 1, sample good arguments."""
+    env_ref = isodatetime_main.DateTimeOperator.ENV_REF
+    ref = os.environ.get(env_ref)
+    for args, out in [
+        (['20200101T00Z'], '20200101T00Z'),
+        (['ref'], '20201225T0000Z'),
+        # UTC mode
+        (['-u', '20200101T00+0100'], '20191231T23+0000'),
+        (['--utc', '20200101T00+0100'], '20191231T23+0000'),
+        # With offsets
+        (['-s', 'P1D', '20191231T00Z'], '20200101T00Z'),
+        (['-s', 'P1D', '--offset=PT1H', '20191231T00Z'], '20200101T01Z'),
+        # Negative duration
+        (['-s', 'P1D', '--offset=-PT1H', '20191231T00Z'], '20191231T23Z'),
+        (['-s', 'P1D', '--offset', '\\-PT1H', '20191231T00Z'],
+         '20191231T23Z'),
+        # Print format
+        (['-f', 'CCYY', '20191231T00Z'], '2019'),
+        (['--format', 'CCYY', '20191231T00Z'], '2019'),
+        (['--print-format', 'CCYY', '20191231T00Z'], '2019'),
+        (['20200101T00-1130', '-f', 'CCYYMMDDThhmm+0000'],
+         '20200101T1130+0000'),
+        # Parse format
+        (['--parse-format=%d/%m/%Y', '-f', 'CCYY-MM-DD', '31/12/2019'],
+         '2019-12-31'),
+        (['-p', '%d/%m/%Y', '-f', 'CCYY-MM-DD', '31/12/2019'],
+         '2019-12-31'),
+    ]:
+        os.environ[env_ref] = '20201225T0000Z'
         try:
-            with self.assertRaises(SystemExit) as ctxmgr:
-                isodatetime_main.main()
-            mock_print.assert_not_called()
-            self.assertEqual(
-                'Invalid ISO 8601 duration representation: PS4',
-                str(ctxmgr.exception))
+            isodatetime_main.main(args)
+            mock_print.assert_called_with(out)
         finally:
-            sys.argv = argv
+            if ref is not None:
+                os.environ[env_ref] = ref
+            else:
+                del os.environ[env_ref]
 
-    @patch('builtins.print')
-    def test_4_good(self, mock_print):
-        """Test calling usage 4, sample good arguments."""
-        argv = sys.argv
-        for args, out in [
-            # Forward
-            (['-u', 'R/2020/P1Y'],
-             '\n'.join('%d-01-01T00:00:00Z' % i for i in range(2020, 2030))),
-            (['-u', 'R3/2020/P1Y'],
-             '\n'.join('%d-01-01T00:00:00Z' % i for i in range(2020, 2023))),
-            (['-u', '--max=5', 'R/2020/P1Y'],
-             '\n'.join('%d-01-01T00:00:00Z' % i for i in range(2020, 2025))),
-            (['-u', '--max=15', 'R/2020/P1Y'],
-             '\n'.join('%d-01-01T00:00:00Z' % i for i in range(2020, 2035))),
-            (['--print-format=%Y', 'R/2020/P1Y'],
-             '\n'.join('%d' % i for i in range(2020, 2030))),
-            # Reverse
-            (['-u', 'R/P1Y/2020'],
-             '\n'.join('%d-01-01T00:00:00Z' % i
-                       for i in range(2020, 2010, -1))),
-        ]:
-            sys.argv = [''] + args
-            try:
-                isodatetime_main.main()
-                mock_print.assert_called_with(out)
-            finally:
-                sys.argv = argv
 
-    @patch('builtins.print')
-    def test_4_bad(self, mock_print):
-        """Test calling usage 4, sample bad arguments."""
-        argv = sys.argv
+@patch('builtins.print')
+def test_1_bad(mock_print):
+    """Test calling usage 1, sample bad arguments."""
+    for args, out in [
+        # Bad time point string
+        (['201abc'], 'Invalid ISO 8601 date representation: 201abc'),
+        # Bad offset string
+        (['-s', 'add-a-year', '2019'], 'add-a-year: bad offset value'),
+    ]:
         mock_print.reset_mock()
-        sys.argv = ['', 'R-1/2020/2025']
+        with pytest.raises(SystemExit) as ctxmgr:
+            isodatetime_main.main(args)
+        mock_print.assert_not_called()
+        assert str(ctxmgr.value) == out
+
+
+@patch('builtins.print')
+def test_2_good(mock_print):
+    """Test calling usage 2, sample good arguments."""
+    env_ref = isodatetime_main.DateTimeOperator.ENV_REF
+    ref = os.environ.get(env_ref)
+    for args, out in [
+        # Same
+        (['ref', 'ref'], 'P0Y'),
+        (['20380119', '20380119'], 'P0Y'),
+        # Positive duration
+        (['20181225', '20191225'], 'P365D'),
+        (['-1', 'PT12H', '-2', 'PT12H', '20181225', '20191225'], 'P365D'),
+        # Negative duration
+        (['20191225', '20181225'], '-P365D'),
+        (['--offset1=-PT6H', '--offset2=-PT6H', '20191225', '20181225'],
+         '-P365D'),
+        (['--offset1', '\\-PT6H', '--offset2', '\\-PT6H', '20191225',
+         '20181225'], '-P365D'),
+    ]:
+        os.environ[env_ref] = '20201225T0000Z'
         try:
-            with self.assertRaises(SystemExit) as ctxmgr:
-                isodatetime_main.main()
-            mock_print.assert_not_called()
-            self.assertEqual(
-                'Invalid ISO 8601 recurrence representation: R-1/2020/2025',
-                str(ctxmgr.exception))
+            isodatetime_main.main(args)
+            mock_print.assert_called_with(out)
         finally:
-            sys.argv = argv
+            if ref is not None:
+                os.environ[env_ref] = ref
+            else:
+                del os.environ[env_ref]
+
+
+@patch('builtins.print')
+def test_2_bad(mock_print):
+    """Test calling usage 2, sample bad arguments."""
+    for args, out in [
+        # Bad time point string
+        (['201abc', '2020'],
+         'Invalid ISO 8601 date representation: 201abc'),
+        # Bad offset string
+        (['-1', 'add-a-year', '2018', '2019'],
+         'add-a-year: bad offset value'),
+    ]:
+        mock_print.reset_mock()
+        with pytest.raises(SystemExit) as ctxmgr:
+            isodatetime_main.main(args)
+        mock_print.assert_not_called()
+        assert str(ctxmgr.value) == out
+
+
+@patch('builtins.print')
+def test_3_good(mock_print):
+    """Test calling usage 3, sample good arguments."""
+    for args, out in [
+        # Same
+        (['--as-total=s', 'PT1H30M'], 5400),
+        (['--as-total=s', 'P1D'], 86400),
+        (['--as-total=h', 'P1D'], 24),
+    ]:
+        isodatetime_main.main(args)
+        mock_print.assert_called_with(out)
+
+
+@patch('builtins.print')
+def test_3_bad(mock_print):
+    """Test calling usage 3, sample bad arguments."""
+    mock_print.reset_mock()
+    with pytest.raises(SystemExit) as ctxmgr:
+        isodatetime_main.main(['--as-total=s', 'PS4'])
+    mock_print.assert_not_called()
+    assert str(ctxmgr.value) == (
+        'Invalid ISO 8601 duration representation: PS4'
+    )
+
+
+@patch('builtins.print')
+def test_4_good(mock_print):
+    """Test calling usage 4, sample good arguments."""
+    for args, out in [
+        # Forward
+        (['-u', 'R/2020/P1Y'],
+         '\n'.join('%d-01-01T00:00:00Z' % i for i in range(2020, 2030))),
+        (['-u', 'R3/2020/P1Y'],
+         '\n'.join('%d-01-01T00:00:00Z' % i for i in range(2020, 2023))),
+        (['-u', '--max=5', 'R/2020/P1Y'],
+         '\n'.join('%d-01-01T00:00:00Z' % i for i in range(2020, 2025))),
+        (['-u', '--max=15', 'R/2020/P1Y'],
+         '\n'.join('%d-01-01T00:00:00Z' % i for i in range(2020, 2035))),
+        (['--print-format=%Y', 'R/2020/P1Y'],
+         '\n'.join('%d' % i for i in range(2020, 2030))),
+        # Reverse
+        (['-u', 'R/P1Y/2020'],
+         '\n'.join('%d-01-01T00:00:00Z' % i
+                   for i in range(2020, 2010, -1))),
+    ]:
+        isodatetime_main.main(args)
+        mock_print.assert_called_with(out)
+
+
+@patch('builtins.print')
+def test_4_bad(mock_print):
+    """Test calling usage 4, sample bad arguments."""
+    mock_print.reset_mock()
+    with pytest.raises(SystemExit) as ctxmgr:
+        isodatetime_main.main(['R-1/2020/2025'])
+    mock_print.assert_not_called()
+    assert str(ctxmgr.value) == (
+        'Invalid ISO 8601 recurrence representation: R-1/2020/2025'
+    )
 
 
 @pytest.mark.parametrize(
@@ -273,7 +231,3 @@ def test_pipe(stdin, args, stdout):
     ).communicate(  # nosec
         stdin.encode()
     )[0].decode().strip() == stdout
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/metomi/isodatetime/tests/test_main.py
+++ b/metomi/isodatetime/tests/test_main.py
@@ -217,6 +217,15 @@ def test_4_bad(mock_print):
     )
 
 
+def test_negative_duration():
+    """Test arg parsing of negative durations."""
+    for variant in ('-P1D', r'\-P1D',):
+        args = isodatetime_main.parse_args(['2000', '-s', variant])
+        assert args.offsets1 == ['-P1D']
+        args = isodatetime_main.parse_args(['2000', rf'-s={variant}'])
+        assert args.offsets1 == ['-P1D']
+
+
 @pytest.mark.parametrize(
     'stdin,args,stdout', [
         ('2000', [], '2000'),


### PR DESCRIPTION
Will close https://github.com/metomi/rose/issues/2569 in combination with a dependency change.

This is more an inconsistency than a bug from the perspective of isodatetime, however, from the Rose side it is a bug as we had previously worked to handle this case.

Before:
```console
$ isodatetime 2000 -s -P1D
isodatetime: error: argument --offset1/--offset/-s/-1: expected one argument
$ isodatetime 2000 -s=-P1D
1999
$ isodatetime 2000 -s \-P1D
isodatetime: error: argument --offset1/--offset/-s/-1: expected one argument
$ isodatetime 2000 -s=\-P1D
1999
```

After:
```console
$ isodatetime 2000 -s -P1D
1999
$ isodatetime 2000 -s=-P1D
1999
$ isodatetime 2000 -s \-P1D
1999
$ isodatetime 2000 -s=\-P1D
1999
```

(note, swap `isodatetime` for `rose date` and you will get the same result)

A bit crude but I think this is ok as no other arguments should start with the string `-P`.