### PR TITLE
Change next release from 2.1 to 3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,9 +11,9 @@ ones in. -->
 
 --------------------------------------------------------------------------------
 
-## isodatetime 2.1.0 (<span actions:bind='release-date'>Upcoming, 2020</span>)
+## isodatetime 3.0.0 (<span actions:bind='release-date'>Upcoming</span>)
 
-This is the 15th release of isodatetime. **Requires Python 3.6+**.
+Requires Python 3.6+
 
 ### Noteworthy Changes
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -25,3 +25,4 @@ markers =
     slow: mark a test as slow - it will be skipped by default (use '-m "slow or not slow"' to run all tests)
 testpaths =
     metomi/isodatetime/tests
+    README.md


### PR DESCRIPTION
I propose changing the upcoming release from 2.1 to 3.0 due to the breaking changes:
- Immutability means you can no longer do things like `my_timepoint.year += 1`
- Replacement of `my_timepoint.get()` with properties
- #183 is sort of like a breaking change

I don't see any reason not to make this a major release. Considering we have been bitten by packages not obeying semver recently (e.g. markupsafe), I think it would be more responsible to make this a major release (even if few people use isodatetime outside of Cylc)

If this is merged I will update the milestone accordingly