### PR TITLE
Fix version of `gh-action-pypi-publish` and add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - 'dependencies'
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - 'dependencies'
+      - 'infrastructure'

--- a/.github/workflows/auto_publish_release.yml
+++ b/.github/workflows/auto_publish_release.yml
@@ -38,7 +38,7 @@ jobs:
       uses: cylc/release-actions/build-python-package@v1
 
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@v1.5.0
       with:
         user: __token__ # uses the API token feature of PyPI - least permissions possible
         password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/auto_publish_release.yml
+++ b/.github/workflows/auto_publish_release.yml
@@ -22,12 +22,12 @@ jobs:
     steps:
 
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ env.MERGE_SHA }}
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.x'
 

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -21,12 +21,12 @@ jobs:
       uses: cylc/release-actions/stage-1/sanitize-inputs@v1
 
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ env.BASE_REF }}
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.x'
 
@@ -52,3 +52,5 @@ jobs:
       uses: cylc/release-actions/stage-1/create-release-pr@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        test-workflows: test.yml


### PR DESCRIPTION
`gh-action-pypi-publish` does not have a `v1` tag like other actions, it was my bad to do that in #200

Good news is we can rely on dependabot to update the version from now on