### PR TITLE
Update changelog [skip ci]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@ ones in. -->
 
 Requires Python 3.7+
 
+### Fixes
+
+[#231](https://github.com/metomi/isodatetime/pull/231):
+Fixed mistakes in the CLI help text.
+
 --------------------------------------------------------------------------------
 
 ## isodatetime 3.0.0 (<span actions:bind='release-date'>Released 2022-03-31</span>)


### PR DESCRIPTION
May as well get out 3.1.0 at the same time as we do Cylc 8.2.2?