### PR TITLE
GH Actions: automatically use latest `pypa/gh-action-pypi-publish`

### DIFF
--- a/.github/workflows/auto_publish_release.yml
+++ b/.github/workflows/auto_publish_release.yml
@@ -38,7 +38,7 @@ jobs:
       uses: cylc/release-actions/build-python-package@v1
 
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.12.2
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__ # uses the API token feature of PyPI - least permissions possible
         password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - '.github/workflows/build.yml'
       - 'README.md'       # check markdown is valid
       - 'MANIFEST.in'     # check packaging
       - 'pyproject.toml'  # check build config
@@ -24,10 +25,12 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.x']
         include:
-          - os: 'macos-latest'
+          - os: ubuntu-22.04
             python: '3.7'
+          - os: 'macos-latest'
+            python: '3.9'
     name: ${{ matrix.os }} py-${{ matrix.python }}
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         coverage: [false]
         include:
           # Modify existing configurations:
@@ -29,11 +29,14 @@ jobs:
             coverage: false
             tz: 'XXX-05:30'  # UTC+05:30
           # Add new configurations:
+          - os: ubuntu-22.04
+            python-version: '3.7'
+            coverage: false
           - os: ubuntu-latest
-            python-version: '3.12'
+            python-version: '3.x'
             coverage: true
           - os: macos-latest
-            python-version: '3.12'
+            python-version: '3.9'
             coverage: false
     name: ${{ matrix.os }} py-${{ matrix.python-version }} ${{ matrix.tz }} ${{ matrix.coverage && '(coverage)' || '' }}
     env:


### PR DESCRIPTION
This will avoid the need for dependabot PRs

Also fixes Python 3.7 on GH Actions by dropping back to Ubuntu 22.04