### PR TITLE
Ensure that malformed datetime points with > 1 "T" raise the correct error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,10 @@ ones in. -->
 
 ### Fixes
 
+[#266](https://github.com/metomi/isodatetime/pull/234):
+Fixed a bug causing unhelpful error messages when parsing a
+malformed time-point containing >1 letter "T".
+
 [#234](https://github.com/metomi/isodatetime/pull/234):
 Fixed behaviour of adding a truncated TimePoint to a normal TimePoint.
 

--- a/metomi/isodatetime/parsers.py
+++ b/metomi/isodatetime/parsers.py
@@ -439,7 +439,7 @@ class TimePointParser(object):
             time_zone_info = (
                 self.process_time_zone_info({}))
             time_info.update(time_zone_info)
-        else:
+        elif len(date_time_time_zone) == 2:
             date, time_time_zone = date_time_time_zone
             if not date and self.allow_truncated:
                 keys = (None, "truncated", "")
@@ -501,6 +501,8 @@ class TimePointParser(object):
             parsed_expr += parser_spec.TIME_DESIGNATOR + (
                 time_expr + time_zone_expr)
             time_info.update(time_zone_info)
+        else:
+            raise ISO8601SyntaxError('time', timepoint_string)
         return date_info, time_info, parsed_expr
 
     def process_time_zone_info(self, time_zone_info=None):

--- a/metomi/isodatetime/tests/test_time_point.py
+++ b/metomi/isodatetime/tests/test_time_point.py
@@ -23,6 +23,8 @@ import pytest
 import random
 
 from metomi.isodatetime.data import TimePoint, Duration, get_days_since_1_ad
+from metomi.isodatetime.parsers import TimePointParser
+from metomi.isodatetime.exceptions import ISO8601SyntaxError
 
 
 def daterange(start_date, end_date):
@@ -123,3 +125,12 @@ def _test_timepoint(test_year):
             test_data.get_calendar_date(),
             test_data.get_hour_minute_second()]
         assert test_data == ctrl_data
+
+
+def test_invalid_point():
+    """Check that invalid points return a sensible failure.
+    """
+    bad = 'STARTTIMET0000Z'
+    tpp = TimePointParser()
+    with pytest.raises(ISO8601SyntaxError, match=bad):
+        tpp.parse(bad)


### PR DESCRIPTION
fail with ISO8601SyntaxError rather than unpacking error.

User's jinja2 shebang fail described in https://github.com/cylc/cylc-flow/pull/6948 was causing input to isodatetime of `{{STARTTIME}}T0000Z` which was not properly handled by isodatetime, resulting in an assignment error. This gave user lots of traceback rather than a simple message.