### PR TITLE
Raise a clear error converting a truncated TimePoint to a date

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,11 @@ Requires Python 3.10+
 
 ### Fixes
 
+[#286](https://github.com/metomi/isodatetime/pull/286):
+Fixed an unhelpful `TypeError` when converting a truncated `TimePoint`
+to a calendar or ordinal date; a clear `ValueError` is now raised
+instead.
+
 [#266](https://github.com/metomi/isodatetime/pull/234):
 Fixed a bug causing unhelpful error messages when parsing a
 malformed time-point containing >1 letter "T".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ below:
 * Ronnie Dutta (Met Office, UK)
 * Walt Whiteside (US)
 * Mark Dawson (Met Office, UK)
+* Vincent Gao (UK)
 
 (All contributors are identifiable with email addresses in the version control
 logs or otherwise.)

--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -1224,6 +1224,10 @@ class TimePoint:
 
     def get_calendar_date(self):
         """Return the year, month-of-year and day-of-month for this date."""
+        if self._truncated:
+            raise ValueError(
+                "Cannot get the calendar date of a truncated "
+                "TimePoint: {0}".format(self))
         if self.get_is_calendar_date():
             return self._year, self._month_of_year, self._day_of_month
         if self.get_is_ordinal_date():
@@ -1251,6 +1255,10 @@ class TimePoint:
 
     def get_ordinal_date(self):
         """Return the year, day-of-year for this date."""
+        if self._truncated:
+            raise ValueError(
+                "Cannot get the ordinal date of a truncated "
+                "TimePoint: {0}".format(self))
         if self.get_is_calendar_date():
             return get_ordinal_date_from_calendar_date(self._year,
                                                        self._month_of_year,

--- a/metomi/isodatetime/tests/test_01.py
+++ b/metomi/isodatetime/tests/test_01.py
@@ -732,6 +732,19 @@ def test_timepoint_subtract_truncated():
         TimePoint(day_of_month=2, truncated=True) - TimePoint(year=2000)
 
 
+def test_timepoint_truncated_to_calendar_ordinal_date():
+    """A truncated TimePoint has no fully-determined date, so converting it
+    to a calendar or ordinal date should raise a clear ValueError rather than
+    an obscure TypeError (GitHub #265)."""
+    point = TimePoint(
+        year=1, week_of_year=2, truncated=True,
+        truncated_property='year_of_decade')
+    with pytest.raises(ValueError, match="Cannot get the calendar date"):
+        point.to_calendar_date()
+    with pytest.raises(ValueError, match="Cannot get the ordinal date"):
+        point.to_ordinal_date()
+
+
 @pytest.mark.parametrize('test', get_duration_subtract_tests())
 def test_timepoint_duration_subtract(test):
     """Test subtracting a duration from a timepoint."""


### PR DESCRIPTION
Fixes #265.

Converting a truncated `TimePoint` to a calendar or ordinal date raised an obscure `TypeError` instead of a clear error:

```python
from metomi.isodatetime.data import TimePoint
a = TimePoint(year=1, week_of_year=2, truncated=True,
              truncated_property='year_of_decade')
a.to_calendar_date()
# TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```

### Cause

`to_calendar_date()` / `to_ordinal_date()` delegate to `get_calendar_date()` / `get_ordinal_date()`. For a truncated week-date point these reach `get_calendar_date_from_week_date(year, week_of_year, day_of_week)` with `day_of_week` unset, so `(week_of_year - 1) * 7 + day_of_week - 1` evaluates `int + None` and raises the unhelpful `TypeError`. A truncated `TimePoint` has no fully-determined year or day, so it fundamentally cannot be converted to an absolute calendar or ordinal date.

### Fix

Guard `get_calendar_date()` and `get_ordinal_date()`: when the point is truncated, raise a clear `ValueError`, mirroring the existing truncated-comparison guard (`"Cannot compare truncated to non-truncated TimePoint: ..."`). The `to_calendar_date()` / `to_ordinal_date()` wrappers surface this directly, and non-truncated conversions are unchanged.

Added a regression test (`test_timepoint_truncated_to_calendar_ordinal_date`) covering both methods, and added my name to the Code Contributors list per CONTRIBUTING.md.

Disclosure: I prepared this fix with AI assistance under my direction; I reviewed and verified the change and the test myself.
