### PR TITLE
fix: allow Feb 29 in truncated dates where year is ambiguous (fixes #264)

### DIFF
--- a/metomi/isodatetime/data.py
+++ b/metomi/isodatetime/data.py
@@ -2030,7 +2030,12 @@ class TimePoint:
         _bounds_checker(self._month_of_year, "month_of_year",
                         min_val=1, max_val=CALENDAR.MONTHS_IN_YEAR)
         if self._month_of_year is not None:
-            if self._year is not None:
+            if self._year is not None and not (
+                self._truncated
+                and self._truncated_property in (
+                    "year_of_decade", "year_of_century"
+                )
+            ):
                 max_days_in_month = get_days_in_month(self._month_of_year,
                                                       self._year)
             else:

--- a/metomi/isodatetime/tests/test_01.py
+++ b/metomi/isodatetime/tests/test_01.py
@@ -402,6 +402,10 @@ def get_timepoint_bounds_tests():
         "in_bounds": [
             {"year": 2020, "month_of_year": 2, "day_of_month": 29},
             {"truncated": True, "month_of_year": 2, "day_of_month": 29},
+            {"truncated": True, "truncated_property": "year_of_decade",
+             "year": 2, "month_of_year": 2, "day_of_month": 29},
+            {"truncated": True, "truncated_property": "year_of_century",
+             "year": 12, "month_of_year": 2, "day_of_month": 29},
             {"year": 2020, "week_of_year": 53},
             {"truncated": True, "week_of_year": 53},
             {"year": 2020, "day_of_year": 366},


### PR DESCRIPTION
## Description
TimePoint(year=2, month_of_year=2, day_of_month=29, truncated=True, truncated_property='year_of_decade') raised BadInputError: day_of_month out of bounds.

## Root Cause
_check_bounds used the partial year value directly for leap-year detection. Year 2 AD is not a leap year, capping Feb at 28 days. But for truncated dates with year_of_decade or year_of_century, the full year is ambiguous — year 2 could be 2012 (a leap year).

## Fix
Use year='leap' for day-of-month bounds when the TimePoint is truncated with a year-level truncation property. Non-truncated dates continue to correctly reject Feb 29 in non-leap years.

Closes #264

This pull request includes code written with the assistance of AI under my direction.